### PR TITLE
fix: [io] Some folder icons are incorrect

### DIFF
--- a/src/dfm-io/dfm-io/utils/dlocalhelper.cpp
+++ b/src/dfm-io/dfm-io/utils/dlocalhelper.cpp
@@ -384,8 +384,12 @@ QVariant DLocalHelper::attributeFromGFileInfo(GFileInfo *gfileinfo, DFileInfo::A
 
         QList<QString> ret;
         auto names = g_themed_icon_get_names(G_THEMED_ICON(icon));
-        for (int j = 0; names && names[j] != nullptr; ++j)
-            ret.append(QString::fromLocal8Bit(names[j]));
+        for (int j = 0; names && names[j] != nullptr; ++j) {
+            if (strcmp(names[j], "folder") == 0)
+                ret.prepend(QString::fromLocal8Bit(names[j]));
+            else
+                ret.append(QString::fromLocal8Bit(names[j]));
+        }
 
         return QVariant(ret);
     }


### PR DESCRIPTION
If the icon names contains "folder," move it to the front

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-189553.html
