### PR TITLE
fix: [ftp/charset] wrong splitter of url's param.

### DIFF
--- a/src/dfm-mount/private/dnetworkmounter.cpp
+++ b/src/dfm-mount/private/dnetworkmounter.cpp
@@ -280,7 +280,7 @@ void DNetworkMounter::mountByGvfs(const QString &address, GetMountPassInfo getPa
     QString mountAddr = address;
     if (address.startsWith("ftp") && secs > 0 && !address.contains("socket_timeout=")) {
         mountAddr += (url.query().isEmpty() ? QString("?socket_timeout=%1").arg(secs)   // address = ftp://1.2.3.4
-                                            : QString(",socket_timeout=%1").arg(secs));   // address = ftp://1.2.3.4?charset=utf8
+                                            : QString("&socket_timeout=%1").arg(secs));   // address = ftp://1.2.3.4?charset=utf8
     }
 
     qInfo() << "protocol: the mountAddress is: " << mountAddr << "and pureAddress is: " << pureAddr;


### PR DESCRIPTION
as title.
the splitter should be '&' rather than ','.

Log: fix ftp charset mount issue.

Bug: https://pms.uniontech.com/bug-view-200759.html
