### PR TITLE
修复匿名挂载长名共享失败时的错误反馈

### DIFF
--- a/src/dfm-mount/private/dnetworkmounter.cpp
+++ b/src/dfm-mount/private/dnetworkmounter.cpp
@@ -456,8 +456,9 @@ DNetworkMounter::MountRet DNetworkMounter::mountWithUserInput(const QString &add
     int errNum = mntRet.value(kDaemonMountRetKeyErrno).toInt();
 
     bool ok = !mpt.isEmpty();
-    DeviceError err = info.anonymous ? DeviceError::kUserErrorNetworkAnonymousNotAllowed
-                                     : static_cast<DeviceError>(errNum);
+    DeviceError err = (info.anonymous && errNum == EACCES)
+            ? DeviceError::kUserErrorNetworkAnonymousNotAllowed
+            : static_cast<DeviceError>(errNum);
     if (ok) {
         err = DeviceError::kNoError;
 


### PR DESCRIPTION
anonymous mount a share which have a log sharename will failed, and
'Anonymout not allowed' is reported which is not correct, the real error
should be 'Cannot make dir'.
only report `Anony...` if mount failed with EACCES error.

Log: fix issue about mount error.

Bug: https://pms.uniontech.com/bug-view-201805.html
