### PR TITLE
fix: [io]Hidden files on the desktop flash by

### DIFF
--- a/src/dfm-io/dfm-io/utils/dlocalhelper.cpp
+++ b/src/dfm-io/dfm-io/utils/dlocalhelper.cpp
@@ -645,8 +645,8 @@ bool DLocalHelper::fileIsHidden(const DFileInfo *dfileinfo, const QSet<QString> 
 {
     if (!dfileinfo)
         return false;
-
-    const QString &fileName = dfileinfo->attribute(DFileInfo::AttributeID::kStandardName, nullptr).toString();
+    // if file not exist DFileInfo::AttributeID::kStandardFileName 返回有错误 bug-200989
+    const QString &fileName = dfileinfo->uri().fileName();
     if (fileName.startsWith(".")) {
         return true;
     } else {


### PR DESCRIPTION
Gio created a temporary. file, but it was soon gone. This is because obtaining the file name for the file is invalid, and there is a problem determining whether it is hidden. Use the URL to obtain the file name of the file.

Log: Hidden files on the desktop flash by
Bug: https://pms.uniontech.com/bug-view-200989.html