### PR TITLE
当操作设备失败时打印错误信息

### DIFF
--- a/src/dfm-mount/lib/dblockdevice.cpp
+++ b/src/dfm-mount/lib/dblockdevice.cpp
@@ -25,6 +25,7 @@ inline void DBlockDevicePrivate::handleErrorAndRelease(CallbackProxy *proxy, boo
     if (!result && gerr) {
         err.code = Utils::castFromGError(gerr);
         err.message = gerr->message;
+        qInfo() << "error occured while operating device" << err.message;
         g_error_free(gerr);
     }
 


### PR DESCRIPTION
as title.

Log: add more error logs.
