### PR TITLE
fix: [io] When copying and replacing files, hidden files may display and disappear

### DIFF
--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -728,10 +728,16 @@ QVariant DFileInfo::attribute(DFileInfo::AttributeID id, bool *success) const
     if (!d->initFinished) {
         bool succ = const_cast<DFileInfoPrivate *>(d.data())->queryInfoSync();
         if (!succ) {
-            if (!d->attributesNoBlockIO.contains(id))
+            if (!d->attributesNoBlockIO.contains(id)) {
+                if (id == DFileInfo::AttributeID::kStandardIsHidden) {
+                    const auto &fileName = d->uri.fileName();
+                    return fileName.startsWith('.');
+                }
+
                 return QVariant();
-            else
+            } else {
                 return const_cast<DFileInfoPrivate *>(d.data())->attributesFromUrl(id);
+            }
         }
     }
 


### PR DESCRIPTION
Failed to retrieve the properties of a hidden file when it does not exist, causing it to be assumed to be non-hidden

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-200989.html
