### PR TITLE
feat: [io]MTP file copy optimization

### DIFF
--- a/include/dfm-io/dfm-io/dfile.h
+++ b/include/dfm-io/dfm-io/dfile.h
@@ -40,14 +40,15 @@ public:
     enum class CopyFlag : uint8_t {
         kNone = 0,   // No flags set.
         kOverwrite = 1,   // Overwrite any existing files.
-        kBackup = 2,   // Make a backup of any existing files.
-        kNoFollowSymlinks = 3,   // Don’t follow symlinks.
-        kAllMetadata = 4,   // Copy all file metadata instead of just default set used for copy.
-        kNoFallbackForMove = 5,   // Don’t use copy and delete fallback if native move not supported.
-        kTargetDefaultPerms = 6,   // Leaves target file with default perms, instead of setting the source file perms.
+        kBackup = (1 << 1),   // Make a backup of any existing files.
+        kNoFollowSymlinks = (1 << 2),   // Don’t follow symlinks.
+        kAllMetadata = (1 << 3),   // Copy all file metadata instead of just default set used for copy.
+        kNoFallbackForMove = (1 << 4),   // Don’t use copy and delete fallback if native move not supported.
+        kTargetDefaultPerms = (1 << 5),   // Leaves target file with default perms, instead of setting the source file perms.
 
-        kUserFlag = 0x10
+        kUserFlag = 0x40
     };
+    Q_DECLARE_FLAGS(CopyFlags, CopyFlag)
 
     enum class SeekType : uint8_t {
         kBegin = 0x00,
@@ -139,6 +140,7 @@ private:
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(DFile::OpenFlags);
 Q_DECLARE_OPERATORS_FOR_FLAGS(DFile::Permissions);
+Q_DECLARE_OPERATORS_FOR_FLAGS(DFile::CopyFlags);
 
 END_IO_NAMESPACE
 Q_DECLARE_METATYPE(dfmio::DFile::Permissions);

--- a/include/dfm-io/dfm-io/dfmio_utils.h
+++ b/include/dfm-io/dfm-io/dfmio_utils.h
@@ -34,7 +34,9 @@ class DFMUtils
 public:
     static bool fileUnmountable(const QString &path);
     static QString devicePathFromUrl(const QUrl &url);
+    static QString deviceNameFromUrl(const QUrl &url);
     static QString fsTypeFromUrl(const QUrl &url);
+    static QString mountPathFromUrl(const QUrl &url);
     static QUrl directParentUrl(const QUrl &url, const bool localFirst = true);
     static bool fileIsRemovable(const QUrl &url);
     static QSet<QString> hideListFromUrl(const QUrl &url);
@@ -54,6 +56,7 @@ public:
     // 通过迭代器去获取回收站数量，并做相同挂载点过滤
     static DEnumeratorFuture *asyncTrashCount();
     static int syncTrashCount();
+    static qint64 deviceBytesFree(const QUrl &url);
 
 private:
     static QMap<QString, QString>

--- a/include/dfm-io/dfm-io/doperator.h
+++ b/include/dfm-io/dfm-io/doperator.h
@@ -34,13 +34,13 @@ public:
 
     bool renameFile(const QString &newName);
     bool renameFile(const QUrl &toUrl);
-    bool copyFile(const QUrl &destUri, DFile::CopyFlag flag, ProgressCallbackFunc func = nullptr, void *progressCallbackData = nullptr);
-    bool moveFile(const QUrl &destUri, DFile::CopyFlag flag, ProgressCallbackFunc func = nullptr, void *progressCallbackData = nullptr);
+    bool copyFile(const QUrl &destUri, DFile::CopyFlags flag, ProgressCallbackFunc func = nullptr, void *progressCallbackData = nullptr);
+    bool moveFile(const QUrl &destUri, DFile::CopyFlags flag, ProgressCallbackFunc func = nullptr, void *progressCallbackData = nullptr);
     // async
     void renameFileAsync(const QString &newName, int ioPriority = 0, FileOperateCallbackFunc func = nullptr, void *userData = nullptr);
-    void copyFileAsync(const QUrl &destUri, DFile::CopyFlag flag, ProgressCallbackFunc progressfunc = nullptr, void *progressCallbackData = nullptr,
+    void copyFileAsync(const QUrl &destUri, DFile::CopyFlags flag, ProgressCallbackFunc progressfunc = nullptr, void *progressCallbackData = nullptr,
                        int ioPriority = 0, FileOperateCallbackFunc operatefunc = nullptr, void *userData = nullptr);
-    void moveFileAsync(const QUrl &destUri, DFile::CopyFlag flag, ProgressCallbackFunc progressFunc = nullptr, void *progressCallbackData = nullptr,
+    void moveFileAsync(const QUrl &destUri, DFile::CopyFlags flag, ProgressCallbackFunc progressFunc = nullptr, void *progressCallbackData = nullptr,
                        int ioPriority = 0, FileOperateCallbackFunc operatefunc = nullptr, void *userData = nullptr);
 
     QString trashFile();

--- a/src/dfm-io/dfm-io/private/doperator_p.h
+++ b/src/dfm-io/dfm-io/private/doperator_p.h
@@ -25,6 +25,7 @@ public:
 
     void setErrorFromGError(GError *gerror);
     GFile *makeGFile(const QUrl &url);
+    void checkAndResetCancel();
 
     static void renameCallback(GObject *sourceObject, GAsyncResult *res, gpointer userData);
     static void copyCallback(GObject *sourceObject, GAsyncResult *res, gpointer userData);


### PR DESCRIPTION
1. Modify the copy flag CopyFlag in DFile (modified to match the GFileCopyFlags flag in gio). 2. Modify the copyFile, moveFile, copyFileAsync, and moveFileAsync in the DOperator class to pass in the CopyFlags (interfaces g_file_move and g_file_copy that are compatible with gio) interface. 3. Implement interface cancel in DOperator. 4. Add interfaces deviceNameFromUrl, mountPathFromUrl, and deviceBytesFree to DFMUtils using gio implementation.

Log: MTP file copy optimization
Task: https://pms.uniontech.com/task-view-272307.html