### PR TITLE
feat: [io]Ctrl+a file operation

### DIFF
--- a/include/dfm-io/dfm-io/denumerator.h
+++ b/include/dfm-io/dfm-io/denumerator.h
@@ -63,6 +63,7 @@ public:
     struct SortFileInfo
     {
         QUrl url;
+        qint64 filesize { 0 };
         bool isFile { false };
         bool isDir { false };
         bool isSymLink { false };

--- a/src/dfm-io/dfm-io/utils/dlocalhelper.cpp
+++ b/src/dfm-io/dfm-io/utils/dlocalhelper.cpp
@@ -847,6 +847,7 @@ QSharedPointer<DEnumerator::SortFileInfo> DLocalHelper::createSortFileInfo(const
     auto name = QString(ent->fts_name);
     auto path = QString(ent->fts_path);
     if (info) {
+        sortPointer->filesize = info->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong();
         sortPointer->isDir = info->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool();
         sortPointer->isFile = !sortPointer->isDir;
         sortPointer->isSymLink = info->attribute(DFileInfo::AttributeID::kStandardIsSymlink).toBool();
@@ -861,6 +862,7 @@ QSharedPointer<DEnumerator::SortFileInfo> DLocalHelper::createSortFileInfo(const
         return sortPointer;
     }
 
+    sortPointer->filesize = ent->fts_statp->st_size;
     sortPointer->isDir = S_ISDIR(ent->fts_statp->st_mode);
     sortPointer->isFile = !sortPointer->isDir;
     sortPointer->isSymLink = S_ISLNK(ent->fts_statp->st_mode);


### PR DESCRIPTION
Add filesize to sortifno, where you already have the size and can save it in advance. When the file is selected, the file size can be obtained.

Log: Optimization of ctrl+a file operation
Task: https://pms.uniontech.com/task-view-269223.html