### PR TITLE
修复一个边缘 Bug

### DIFF
--- a/src/dfm-mount/private/dnetworkmounter.cpp
+++ b/src/dfm-mount/private/dnetworkmounter.cpp
@@ -104,10 +104,15 @@ QList<QVariantMap> DNetworkMounter::loginPasswd(const QString &address)
                     if (!info)
                         return;
                     info->insert(static_cast<char *>(k), static_cast<char *>(v));
-                    qDebug() << "######" << *info;
+                    qInfo() << "found saved login info:" << *info;
                 },
                 &attr);
-        passwds.append(attr);
+        if (attr.contains(kSchemaDomain) && attr.contains(kSchemaProtocol)
+            && attr.contains(kSchemaServer) && attr.contains(kSchemaUser))
+            passwds.append(attr);
+        else
+            qInfo() << "got invalid saved keyring, ignore." << attr;
+
         items = items->next;
     }
 
@@ -477,9 +482,9 @@ DNetworkMounter::MountRet DNetworkMounter::mountWithSavedInfos(const QString &ad
                            QDBusConnection::systemBus());
 
     for (const auto &login : infos) {
-        QVariantMap param { { kLoginUser, login.value(kSchemaUser) },
-                            { kLoginDomain, login.value(kSchemaDomain) },
-                            { kLoginPasswd, login.value(kLoginPasswd) },
+        QVariantMap param { { kLoginUser, login.value(kSchemaUser, "") },
+                            { kLoginDomain, login.value(kSchemaDomain, "") },
+                            { kLoginPasswd, login.value(kLoginPasswd, "") },
                             { kLoginTimeout, secs },
                             { kMountFsType, "cifs" } };
 


### PR DESCRIPTION
升级系统前保存了 smb 密码，在升级系统后，由某种机制触发了 gnome keyring 的重新校验，此时输入了错误的密码，导致在挂载 smb 的时候获取到的密码信息被编码。
正常期望应该获取到 {"domain": "workgroup"} 这样的键值对，但获取到的是 {"gkr:compat:hash:domain":, "sdfjaslf2foaskjf;klaj;ka"} 这类编码后的键值对。
然而在使用这个密码的时候，没有检验其中是否包含 "domain/server/user" 等键值，而是直接使用 QVariantMap::value("domain") 函数获取到了非法的 QVariant 对象。
该对象传入 DBus 进行接口调用的时候导致崩溃，此种崩溃的 Core 信息也没有任何有帮助的内容。

该修改方案为在获取后先判定是否包含预期键值，若不包含，则进行用户鉴权流程；在使用调用 value 函数时传递默认值，避免崩溃。

smb password was saved, after the system upgraded, the gnome keyring was
destoried by user's wrong inputs, then the query password operation got
encoded password infos with "gkr:compat:hash:" prefix while we expected
"domain" whitout prefixs.
there is no validate with the queried values, the password info is saved
into a QVairantMap and is used later.
when use the QVariantMap, the value is obtained without a default value,
so got an invalid QVariant value, the invalid value was passed to the
DBus API, and then the app crash without any useful coredump.

Log: fix a corner crash when mount by CIFS.

Bug: https://pms.uniontech.com/bug-view-205677.html
