### PR TITLE
refactor: Add Iterator initialization interface

### DIFF
--- a/include/dfm-io/dfm-io/denumerator.h
+++ b/include/dfm-io/dfm-io/denumerator.h
@@ -112,6 +112,7 @@ public:
     DEnumeratorFuture *asyncIterator();
     void startAsyncIterator();
     bool isAsyncOver() const;
+    bool initEnumerator(const bool oneByone = true);
 
 private:
     QSharedPointer<DEnumeratorPrivate> d;

--- a/src/dfm-io/dfm-io/private/denumerator_p.h
+++ b/src/dfm-io/dfm-io/private/denumerator_p.h
@@ -45,7 +45,7 @@ public:
     void checkAndResetCancel();
     void setErrorFromGError(GError *gerror);
     bool checkFilter();
-    FTS *openDirByfts();
+    bool openDirByfts();
     void insertSortFileInfoList(QList<QSharedPointer<DEnumerator::SortFileInfo>> &fileList,
                                 QList<QSharedPointer<DEnumerator::SortFileInfo>> &dirList,
                                 FTSENT *ent,
@@ -91,6 +91,7 @@ public:
     ulong enumTimeout { 0 };
     bool ftsCanceled { false };
     std::atomic_bool inited { false };
+    FTS *fts { nullptr };
     bool enumSubDir { false };
     bool enumLinks { false };
     std::atomic_bool async { false };


### PR DESCRIPTION
The dfmio Iterator is a gio Iterator created in hasnext. The dde-file-manager does not know when the initialization is complete. Now add a display call.

Log: Add Iterator initialization interface