### PR TITLE
fix: [crash] The app crashes when opening the location of the search results file

### DIFF
--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -433,7 +433,7 @@ QVariant DFileInfoPrivate::attributesFromUrl(DFileInfo::AttributeID id)
             return fullName.mid(pos2 + 1);
     }
     case DFileInfo::AttributeID::kStandardFilePath: {
-        g_autofree gchar *name = g_path_get_dirname(q->uri().toString().toStdString().c_str());
+        g_autofree gchar *name = g_path_get_dirname(q->uri().path().toStdString().c_str());
         if (name != nullptr)
             return QString::fromLocal8Bit(name);
         return "";


### PR DESCRIPTION
1.The search result file does not exist
2.If the absolute path obtained by fileinfo does not exist, the parent directory is obtained, but the format of the returned path is file://xxx.

Log: fix bug
Bug: https://pms.uniontech.com/bug-view-211957.html
