### PR TITLE
fix: [io]dde-file-manager crashes when replacing files in vault

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+util-dfm (1.2.14) unstable; urgency=medium
+
+  * update version to 1.2.14
+
+ -- lvwujun <lvwujun@uniontech.com>  Fri, 4 Aug 2023 14:48:12 +0800
+
 util-dfm (1.2.13) unstable; urgency=medium
 
   * update version to 1.2.13

--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -615,7 +615,8 @@ void DFileInfoPrivate::queryInfoAsyncCallback(GObject *sourceObject, GAsyncResul
     GFileInfo *fileinfo = g_file_query_info_finish(file, res, &gerror);
 
     if (gerror) {
-        data->me->setErrorFromGError(gerror);
+        if (data->me)
+            data->me->setErrorFromGError(gerror);
         freeQueryInfoAsyncOp(data);
         return;
     }


### PR DESCRIPTION
Error when fileinfo query is destroyed, didn't bother to determine pointer as nullptr

Log: dde-file-manager crashes when replacing files in vault