### PR TITLE
fix: use values() instead of deprecated toList()

### DIFF
--- a/src/dfm-mount/lib/dblockmonitor.cpp
+++ b/src/dfm-mount/lib/dblockmonitor.cpp
@@ -187,7 +187,7 @@ QStringList DBlockMonitorPrivate::resolveDeviceOfDrive(const QString &drvObjPath
 {
     if (q->status() != MonitorStatus::kMonitoring)
         initDevices();
-    return blksOfDrive.value(drvObjPath).toList();
+    return blksOfDrive.value(drvObjPath).values();
 }
 
 void DBlockMonitorPrivate::onObjectAdded(GDBusObjectManager *mng, GDBusObject *obj, gpointer userData)

--- a/src/dfm-mount/lib/dprotocolmonitor.cpp
+++ b/src/dfm-mount/lib/dprotocolmonitor.cpp
@@ -113,7 +113,7 @@ DeviceType DProtocolMonitorPrivate::monitorObjectType() const
 
 QStringList DProtocolMonitorPrivate::getDevices()
 {
-    return cachedDevices.toList();
+    return cachedDevices.values();
 }
 
 QSharedPointer<DDevice> DProtocolMonitorPrivate::createDevice(const QString &id)


### PR DESCRIPTION
Fixes these warnings: "warning: ‘QList<T> QSet<T>::toList() const [with T = QString]’ is deprecated: Use values() instead. [-Wdeprecated-declarations]"