### PR TITLE
fix: [io]Copying a file to a USB flash drive, the file occasionally flickers

### DIFF
--- a/include/dfm-io/dfm-io/dfileinfo.h
+++ b/include/dfm-io/dfm-io/dfileinfo.h
@@ -234,6 +234,7 @@ public:
     char *queryAttributes() const;
     DFileInfo::FileQueryInfoFlags queryInfoFlag() const;
     QString dump() const;
+    bool queryAttributeFinished() const;
 
 private:
     QSharedDataPointer<DFileInfoPrivate> d;

--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -336,8 +336,10 @@ bool DEnumeratorPrivate::hasNext()
 
     if (!gfileInfo)
         return hasNext();
-
-    nextUrl = QUrl::fromLocalFile(uri.path() + "/" + QString(g_file_info_get_name(gfileInfo)));
+    auto path = uri.path()  == "/" ?
+                "/" + QString(g_file_info_get_name(gfileInfo)) :
+                uri.path() + "/" + QString(g_file_info_get_name(gfileInfo));
+    nextUrl = QUrl::fromLocalFile(path);
 
     dfileInfoNext = DLocalHelper::createFileInfoByUri(nextUrl, g_file_info_dup(gfileInfo), FILE_DEFAULT_ATTRIBUTES,
                                                       enumLinks ? DFileInfo::FileQueryInfoFlags::kTypeNone : DFileInfo::FileQueryInfoFlags::kTypeNoFollowSymlinks);

--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -17,6 +17,7 @@
 
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <execinfo.h>
 
 USING_IO_NAMESPACE
 
@@ -1083,4 +1084,9 @@ QString DFileInfo::dump() const
         }
     }
     return ret;
+}
+
+bool DFileInfo::queryAttributeFinished() const
+{
+    return d->initFinished;
 }

--- a/src/dfm-io/dfm-io/dwatcher.cpp
+++ b/src/dfm-io/dfm-io/dwatcher.cpp
@@ -136,6 +136,7 @@ DWatcher::DWatcher(const QUrl &uri, QObject *parent)
 
 DWatcher::~DWatcher()
 {
+    stop();
 }
 
 QUrl DWatcher::uri() const


### PR DESCRIPTION
Calling customAttribute function during asynchronous file info query, refreshing under multithreading causes gfileinfo to destruct

Log: Copying a file to a USB flash drive, the file occasionally flickers
Bug: https://pms.uniontech.com/bug-view-215169.html https://pms.uniontech.com/bug-view-222077.html