### PR TITLE
fix: [io]After FTP mounting, I enter the directory without permissions

### DIFF
--- a/src/dfm-io/dfm-io/private/dfileinfo_p.h
+++ b/src/dfm-io/dfm-io/private/dfileinfo_p.h
@@ -62,6 +62,7 @@ public:
     void cacheAttributes();
     DFile::Permissions permissions() const;
     bool exists() const;
+    QVariant accessPermission(const DFileInfo::AttributeID &id);
 
     static void queryInfoAsyncCallback(GObject *sourceObject, GAsyncResult *res, gpointer userData);
     static void queryInfoAsyncCallback2(GObject *sourceObject, GAsyncResult *res, gpointer userData);


### PR DESCRIPTION
The gfileinfo that comes out of the gio asynchronous iteration does not have the accessread, accesswrite, and accesssexecute attributes. Completing these three attributes.

Log: After FTP mounting, I enter the directory without permissions
Bug: https://pms.uniontech.com/bug-view-224901.html