### PR TITLE
fix: [mount] retry the mount process when the auto mount failed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+util-dfm (1.2.18) unstable; urgency=medium
+
+  * update version to 1.2.18
+
+ -- lvwujun <lvwujun@uniontech.com>  Thur, 2 Nov 2023 11:19:21 +0800
+
 util-dfm (1.2.17) unstable; urgency=medium
 
   * update version to 1.2.17

--- a/src/dfm-mount/lib/dblockdevice.cpp
+++ b/src/dfm-mount/lib/dblockdevice.cpp
@@ -48,6 +48,8 @@ void DBlockDevicePrivate::mountAsyncCallback(GObject *sourceObj, GAsyncResult *r
     GError *err = nullptr;
     g_autofree char *mountPoint = nullptr;
     bool result = udisks_filesystem_call_mount_finish(fs, &mountPoint, res, &err);
+    if(mountPoint)
+        result = true;
     handleErrorAndRelease(proxy, result, err, mountPoint);   // ignore mount point, which will be notified by onPropertyChanged
 }
 


### PR DESCRIPTION
if the mount point is not empty that means this dev has been mounted

Log: retry the mount process when the auto mount failed
Bug: https://pms.uniontech.com/bug-view-222961.html