### PR TITLE
fix: When decompressing a compressed file containing 10000 empty files, the dde-file-manager crashes

### DIFF
--- a/include/dfm-io/dfm-io/dfileinfo.h
+++ b/include/dfm-io/dfm-io/dfileinfo.h
@@ -237,7 +237,7 @@ public:
     bool queryAttributeFinished() const;
 
 private:
-    QSharedDataPointer<DFileInfoPrivate> d;
+    mutable QSharedDataPointer<DFileInfoPrivate> d;
 };
 
 END_IO_NAMESPACE

--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -759,6 +759,7 @@ QVariant DFileInfo::attribute(DFileInfo::AttributeID id, bool *success) const
         if (d->gfileinfo) {
             DFMIOErrorCode errorCode(DFM_IO_ERROR_NONE);
             if (!d->attributesRealizationSelf.contains(id)) {
+                QMutexLocker lk(&d->mutex);
                 retValue = DLocalHelper::attributeFromGFileInfo(d->gfileinfo, id, errorCode);
                 if (errorCode != DFM_IO_ERROR_NONE)
                     const_cast<DFileInfoPrivate *>(d.data())->error.setCode(errorCode);

--- a/src/dfm-io/dfm-io/private/dfileinfo_p.h
+++ b/src/dfm-io/dfm-io/private/dfileinfo_p.h
@@ -96,6 +96,7 @@ public:
     QMap<DFileInfo::AttributeID, QVariant> caches;
     std::atomic_bool cacheing { false };
     std::atomic_bool refreshing { false };
+    QMutex mutex;
 
     DFMIOError error;
 };


### PR DESCRIPTION
When receiving file updates, both the filesortwork thread and the fileinfocache thread call the Gio property acquisition interface simultaneously, causing a crash. Lock when obtaining attributes for dfm-io.

Log: When decompressing a compressed file containing 10000 empty files, the dde-file-manager crashes
Bug: https://pms.uniontech.com/bug-view-237837.html