### PR TITLE
fix: [dfmio] Check thumbail in trash crash

### DIFF
--- a/src/dfm-io/dfm-io/dfmio_utils.cpp
+++ b/src/dfm-io/dfm-io/dfmio_utils.cpp
@@ -47,7 +47,7 @@ QString DFMUtils::devicePathFromUrl(const QUrl &url)
         g_autofree gchar *uri = g_file_get_uri(rootFile);
         return QString::fromLocal8Bit(uri);
     } else {
-        g_autoptr(GUnixMountEntry) mount = g_unix_mount_for(g_file_peek_path(gfile), nullptr);
+        g_autoptr(GUnixMountEntry) mount = g_unix_mount_for(g_file_get_path(gfile), nullptr);
         if (mount)
             return QString::fromLocal8Bit(g_unix_mount_get_device_path(mount));
     }


### PR DESCRIPTION
1. when the url is trash and has parent dir, the g_file_peek_path while crash.
2. use the g_file_get_path replace g_file_peek_path

Log: fix issue
Bug: https://pms.uniontech.com/bug-view-241241.html