### PR TITLE
fix: After the SFTP network was disconnected, dde-file-manager froze,add GVFS file detection and improve symlink handling

### DIFF
--- a/include/dfm-io/dfm-io/dfmio_utils.h
+++ b/include/dfm-io/dfm-io/dfmio_utils.h
@@ -58,6 +58,7 @@ public:
     static int syncTrashCount();
     static qint64 deviceBytesFree(const QUrl &url);
     static bool supportTrash(const QUrl &url);
+    static bool isGvfsFile(const QUrl &url);
 
 private:
     static QMap<QString, QString>

--- a/src/dfm-io/dfm-io/dfmio_utils.cpp
+++ b/src/dfm-io/dfm-io/dfmio_utils.cpp
@@ -334,6 +334,19 @@ bool dfmio::DFMUtils::supportTrash(const QUrl &url)
     return true;
 }
 
+bool DFMUtils::isGvfsFile(const QUrl &url)
+{
+    if (!url.isValid())
+        return false;
+
+    const QString &path = url.toLocalFile();
+    static const QString gvfsMatch { "(^/run/user/\\d+/gvfs/|^/root/.gvfs/|^/media/[\\s\\S]*/smbmounts)" };
+    // TODO(xust) /media/$USER/smbmounts might be changed in the future.
+    QRegularExpression re { gvfsMatch };
+    QRegularExpressionMatch match { re.match(path) };
+    return match.hasMatch();
+}
+
 QMap<QString, QString> DFMUtils::fstabBindInfo()
 {
     static QMutex mutex;

--- a/src/dfm-io/dfm-io/utils/dlocalhelper.cpp
+++ b/src/dfm-io/dfm-io/utils/dlocalhelper.cpp
@@ -907,12 +907,15 @@ QSharedPointer<DEnumerator::SortFileInfo> DLocalHelper::createSortFileInfo(const
         if (size > 0) {
             QString symlinkTagetPath = QString::fromUtf8(buffer, static_cast<int>(size));
             sortPointer->symlinkUrl = QUrl::fromLocalFile(symlinkTagetPath);
-            struct stat st;
-            if (stat(symlinkTagetPath.toStdString().c_str(),&st) == 0)
-                sortPointer->isDir = S_ISDIR(st.st_mode);
         }
     } else {
         sortPointer->isDir = S_ISDIR(ent->fts_statp->st_mode);
+    }
+
+    if (sortPointer->symlinkUrl.isValid() && !DFMUtils::isGvfsFile(sortPointer->symlinkUrl)) {
+        struct stat st;
+        if (stat(sortPointer->symlinkUrl.path().toStdString().c_str(),&st) == 0)
+            sortPointer->isDir = S_ISDIR(st.st_mode);
     }
 
     sortPointer->isFile = !sortPointer->isDir;

--- a/src/dfm-io/dfm-io/utils/dlocalhelper.h
+++ b/src/dfm-io/dfm-io/utils/dlocalhelper.h
@@ -8,6 +8,7 @@
 #include <dfm-io/dfmio_global.h>
 #include <dfm-io/dfileinfo.h>
 #include <dfm-io/denumerator.h>
+#include <dfm-io/dfmio_utils.h>
 
 #include <gio/gio.h>
 


### PR DESCRIPTION
- Add isGvfsFile utility function to detect GVFS paths
- Update symlink handling in DLocalHelper to avoid stat calls on GVFS files
- Add regex pattern to match GVFS paths including /run/user/*/gvfs, /root/.gvfs, and /media/*/smbmounts

This change improves performance by preventing unnecessary stat calls on GVFS symlinks and adds better support for GVFS file system detection.

Log: After the SFTP network was disconnected, dde-file-manager froze
Bug: https://pms.uniontech.com/bug-view-278533.html