### PR TITLE
fix: Fixed the issue that sambda cannot be uninstalled in an immutabl…

### DIFF
--- a/src/dfm-mount/lib/dprotocoldevice.cpp
+++ b/src/dfm-mount/lib/dprotocoldevice.cpp
@@ -297,7 +297,7 @@ bool DProtocolDevicePrivate::unmount(const QVariantMap &opts)
         return true;
     } else {
         QString mpt = mountPoint(mountHandler);
-        if (mpt.contains(QRegularExpression("^/media/.*/smbmounts/")) && DNetworkMounter::isDaemonMountEnable()) {
+        if (mpt.contains(QRegularExpression("^(?:/run/media|/media)/.*")) && DNetworkMounter::isDaemonMountEnable()) {
             return DNetworkMounter::unmountNetworkDev(mpt);
         } else {
             GMountOperation *operation { nullptr };
@@ -335,7 +335,7 @@ void DProtocolDevicePrivate::unmountAsync(const QVariantMap &opts, DeviceOperate
         return;
     } else {
         QString mpt = mountPoint(mountHandler);
-        if (mpt.contains(QRegularExpression("^/media/.*/smbmounts/")) && DNetworkMounter::isDaemonMountEnable()) {
+        if (mpt.contains(QRegularExpression("^(?:/run/media|/media)/.*")) && DNetworkMounter::isDaemonMountEnable()) {
             DNetworkMounter::unmountNetworkDevAsync(mpt, cb);
         } else {
             GCancellable *cancellable { nullptr };


### PR DESCRIPTION
…e system

The media path mapping changes in the immutable system lead to the inability to correctly match the path. Modify the regular expression so that it can match

log: Fixed the issue that sambda cannot be uninstalled in an immutable system
bug: https://pms.uniontech.com/bug-view-277301.html