### PR TITLE
feat: handle Block::Configuration property

### DIFF
--- a/include/dfm-mount/dfm-mount/base/dmountutils.h
+++ b/include/dfm-mount/dfm-mount/base/dmountutils.h
@@ -65,6 +65,7 @@ public:
      * \return
      */
     static QStringList gcharvToQStringList(char **tmp);
+    static QVariant gvariantToQVariant(GVariant *value);
 
     template<typename FromClass, typename ToClass>
     static inline ToClass *castClassFromTo(FromClass *p)

--- a/src/dfm-mount/example/main.cpp
+++ b/src/dfm-mount/example/main.cpp
@@ -5,8 +5,7 @@
 #include <QApplication>
 #include <QDebug>
 
-#include <dfm-mount/dprotocoldevice.h>
-#include <dfm-mount/ddevicemanager.h>
+#include "dfm-mount/dmount.h"
 
 using namespace dfmmount;
 int main(int argc, char **argv)

--- a/src/dfm-mount/lib/base/dmountutils.cpp
+++ b/src/dfm-mount/lib/base/dmountutils.cpp
@@ -864,3 +864,36 @@ QString Utils::currentUser()
         return userInfo->pw_name;
     return "";
 }
+
+QVariant Utils::gvariantToQVariant(GVariant *value)
+{
+    if (!value)
+        return QVariant();
+
+    const GVariantType *type = g_variant_get_type(value);
+    if (g_variant_type_equal(type, G_VARIANT_TYPE_STRING)) {
+        return QString::fromUtf8(g_variant_get_string(value, nullptr));
+    } else if (g_variant_type_equal(type, G_VARIANT_TYPE_BYTESTRING)) {
+        return QByteArray(g_variant_get_bytestring(value));
+    } else if (g_variant_type_equal(type, G_VARIANT_TYPE_BOOLEAN)) {
+        return bool(g_variant_get_boolean(value));
+    } else if (g_variant_type_equal(type, G_VARIANT_TYPE_BYTE)) {
+        return quint8(g_variant_get_byte(value));
+    } else if (g_variant_type_equal(type, G_VARIANT_TYPE_INT16)) {
+        return qint16(g_variant_get_int16(value));
+    } else if (g_variant_type_equal(type, G_VARIANT_TYPE_UINT16)) {
+        return quint16(g_variant_get_uint16(value));
+    } else if (g_variant_type_equal(type, G_VARIANT_TYPE_INT32)) {
+        return qint32(g_variant_get_int32(value));
+    } else if (g_variant_type_equal(type, G_VARIANT_TYPE_UINT32)) {
+        return quint32(g_variant_get_uint32(value));
+    } else if (g_variant_type_equal(type, G_VARIANT_TYPE_INT64)) {
+        return qint64(g_variant_get_int64(value));
+    } else if (g_variant_type_equal(type, G_VARIANT_TYPE_UINT64)) {
+        return quint64(g_variant_get_uint64(value));
+    } else if (g_variant_type_equal(type, G_VARIANT_TYPE_DOUBLE)) {
+        return g_variant_get_double(value);
+    }   // Not all processed
+
+    return QVariant();
+}


### PR DESCRIPTION
Added new utility function gvariantToQVariant to convert GVariant types
to QVariant,
supporting various data types including string, boolean, numeric types
etc.
Implemented block configuration property handling in DBlockDevice.

Log: Added GVariant conversion utility and block config support
