### PR TITLE
fix: Add D-Bus service monitoring for UDisks

### DIFF
--- a/src/dfm-mount/private/dblockmonitor_p.h
+++ b/src/dfm-mount/private/dblockmonitor_p.h
@@ -11,6 +11,7 @@
 
 #include <QMap>
 #include <QSet>
+#include <QDBusServiceWatcher>
 
 extern "C" {
 #include <udisks/udisks.h>
@@ -33,6 +34,8 @@ public:
 
     bool startMonitor() DMNT_OVERRIDE;
     bool stopMonitor() DMNT_OVERRIDE;
+    bool startDeviceMonitor();
+    bool stopDeviceMonitor();
     DeviceType monitorObjectType() const DMNT_OVERRIDE;
     QStringList getDevices() DMNT_OVERRIDE;
     QSharedPointer<DDevice> createDeviceById(const QString &id) DMNT_OVERRIDE;
@@ -53,6 +56,7 @@ private:
 
 public:
     UDisksClient *client = nullptr;
+    QDBusServiceWatcher *watcher = nullptr;
 
     static QMap<QString, QSet<QString>> blksOfDrive;
 };


### PR DESCRIPTION
Implement QDBusServiceWatcher to monitor the UDisks service status. The changes include:
- Starting and stopping device monitoring based on the service owner change.
- Enhanced logging for service status updates.

Log: This addition improves the responsiveness of the block monitor to changes in the UDisks service availability.
Bug: https://pms.uniontech.com/bug-view-307463.html
