### PR TITLE
fix: Update DBlockMonitorPrivate destructor to use deleteLater for watcher

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+util-dfm (1.3.14) unstable; urgency=medium
+
+  * fix: Update DBlockMonitorPrivate destructor to use deleteLater for watcher
+
+ -- Liu Zhangjian <liuzhangjian@uniontech.com>  Wed, 02 Apr 2025 17:15:50 +0800
+
 util-dfm (1.3.13) unstable; urgency=medium
 
   * fix bug

--- a/src/dfm-mount/lib/dblockmonitor.cpp
+++ b/src/dfm-mount/lib/dblockmonitor.cpp
@@ -52,8 +52,10 @@ DBlockMonitorPrivate::~DBlockMonitorPrivate()
         client = nullptr;
     }
 
-    if (watcher)
-        delete watcher;
+    if (watcher) {
+        watcher->deleteLater();
+        watcher = nullptr;
+    }
 }
 
 bool DBlockMonitorPrivate::startMonitor()


### PR DESCRIPTION
Refactor the destructor of DBlockMonitorPrivate to call deleteLater on the watcher object, ensuring proper cleanup and avoiding potential crashes. This change enhances the stability of the block monitor during shutdown.
