### PR TITLE
fix: Refactor cancellation handling in DEnumerator, DFile, and DFileInfo

### DIFF
--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -114,8 +114,10 @@ bool DEnumeratorPrivate::createEnumerator(const QUrl &url, QPointer<DEnumeratorP
 void DEnumeratorPrivate::checkAndResetCancel()
 {
     if (cancellable) {
-        g_object_unref(cancellable);
-        cancellable = nullptr;
+        if (!g_cancellable_is_cancelled(cancellable))
+            g_cancellable_cancel(cancellable);
+        g_cancellable_reset(cancellable);
+        return;
     }
     cancellable = g_cancellable_new();
 }

--- a/src/dfm-io/dfm-io/dfile.cpp
+++ b/src/dfm-io/dfm-io/dfile.cpp
@@ -44,8 +44,10 @@ void DFilePrivate::setErrorFromGError(GError *gerror)
 void DFilePrivate::checkAndResetCancel()
 {
     if (cancellable) {
-        g_object_unref(cancellable);
-        cancellable = nullptr;
+        if (!g_cancellable_is_cancelled(cancellable))
+            g_cancellable_cancel(cancellable);
+        g_cancellable_reset(cancellable);
+        return;
     }
     cancellable = g_cancellable_new();
 }

--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -495,8 +495,10 @@ QVariant DFileInfoPrivate::attributesFromUrl(DFileInfo::AttributeID id)
 void DFileInfoPrivate::checkAndResetCancel()
 {
     if (gcancellable) {
-        g_object_unref(gcancellable);
-        gcancellable = nullptr;
+        if (!g_cancellable_is_cancelled(gcancellable))
+            g_cancellable_cancel(gcancellable);
+        g_cancellable_reset(gcancellable);
+        return;
     }
     gcancellable = g_cancellable_new();
 }


### PR DESCRIPTION
- Updated checkAndResetCancel() methods in DEnumeratorPrivate, DFilePrivate, and DFileInfoPrivate to improve cancellation logic.
- Now, instead of unreferencing and recreating the cancellable object, the code checks if the cancellable is already cancelled, cancels it if not, and then resets it using g_cancellable_reset().
- This change avoids unnecessary object recreation and ensures proper cancellation state management.

Log: Refactor cancellation handling in DEnumerator, DFile, and DFileInfo