### PR TITLE
feat: Add file name index status retrieval functionality

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+util-dfm (1.3.19) unstable; urgency=medium
+
+  * add new interface `fileNameIndexStatus`
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Tue, 29 Apr 2025 17:55:09 +0800
+
 util-dfm (1.3.18) unstable; urgency=medium
 
   * FileNameRealTimeStrategy 

--- a/include/dfm-search/dfm-search/dsearch_global.h
+++ b/include/dfm-search/dfm-search/dsearch_global.h
@@ -103,6 +103,19 @@ bool isPathInFileNameIndexDirectory(const QString &path);
 bool isFileNameIndexDirectoryAvailable();
 
 /**
+ * @brief Returns the current indexing status of the file name database.
+ *
+ * Possible status values:
+ * - "loading"     : Initial loading of existing index
+ * - "scanning"    : Actively scanning filesystem for changes
+ * - "monitoring"  : Scan complete, now watching for filesystem events
+ * - "closed"      : Normal shutdown state (anything terminated properly)
+ *
+ * @return QString The current status string (lowercase)
+ */
+std::optional<QString> fileNameIndexStatus();
+
+/**
  * @brief Get the filename index directory path.
  * This function provides the path to the directory where the filename index is stored,
  * which is essential for performing searches on indexed filenames.

--- a/src/dfm-search/dfm-search-client/main.cpp
+++ b/src/dfm-search/dfm-search-client/main.cpp
@@ -275,12 +275,56 @@ void testPinyin()
     }
 }
 
+void testAnythingStatus()
+{
+    qDebug() << "=== Starting Anything Status Test ===";
+
+    // 测试状态获取
+    auto status = Global::fileNameIndexStatus();
+
+    // 结果验证
+    if (!status.has_value()) {
+        qWarning() << "Test Failed: Could not retrieve status (file missing/permission error?)";
+        return;
+    }
+
+    // 定义有效状态列表（小写）
+    static const QSet<QString> validStatuses {
+        "loading",
+        "scanning",
+        "monitoring",
+        "closed"
+    };
+
+    // 状态有效性检查
+    const QString currentStatus = status.value();
+    if (!validStatuses.contains(currentStatus)) {
+        qWarning() << "Test Failed: Invalid anything status value:" << currentStatus
+                   << "\nExpected one of:" << validStatuses.values();
+        return;
+    }
+
+    // 成功输出
+    qInfo() << "Test Passed. Current anything status:" << currentStatus;
+
+    // 附加信息：打印时间戳（如果测试需要）
+    /*
+    QString statusFile = QDir(Global::fileNameIndexDirectory()).filePath("status.json");
+    QFile file(statusFile);
+    if (file.open(QIODevice::ReadOnly)) {
+        QJsonObject json = QJsonDocument::fromJson(file.readAll()).object();
+        qDebug() << "Last update:" << json["time"].toString();
+    }
+    */
+}
+
 int main(int argc, char *argv[])
 {
     QCoreApplication a(argc, argv);
 
     testGlobal();
     testPinyin();
+    testAnythingStatus();
 
     QCommandLineParser parser;
     parser.setApplicationDescription("DFM Search Client");


### PR DESCRIPTION
This commit introduces a new function, `fileNameIndexStatus`, to retrieve the current indexing status of the file name database. The function checks the availability of the index directory and reads the status from a JSON file, returning the status as a lowercase string. Additionally, a corresponding test function, `testAnythingStatus`, has been implemented to validate the status retrieval process and ensure it returns expected values.

Log: Add file name index status retrieval functionality