### PR TITLE
feat: Implement extended AND search behavior for filename and content…

### DIFF
--- a/include/dfm-search/dfm-search/contentsearchapi.h
+++ b/include/dfm-search/dfm-search/contentsearchapi.h
@@ -74,6 +74,30 @@ public:
      */
     bool isFullTextRetrievalEnabled() const;
 
+    /**
+     * @brief Sets whether the extended AND search behavior across 'contents' and 'filename' fields is enabled.
+     * @param enabled True to enable the feature, false to disable it.
+     * @see isFilenameContentMixedAndSearchEnabled() for a detailed description of the behavior.
+     */
+    void setFilenameContentMixedAndSearchEnabled(bool enabled);
+
+    /**
+     * @brief Checks if the extended AND search behavior across 'contents' and 'filename' fields is enabled.
+     *
+     * When enabled (returns true), boolean AND queries will search for terms such that:
+     * 1. All terms must be present, potentially distributed between the 'contents' and 'filename' fields.
+     *    (e.g., termA in 'contents', termB in 'filename').
+     * 2. A match is explicitly excluded if all search terms are found *only* within the 'filename' field.
+     *    (e.g., termA in 'filename', termB in 'filename' -- this specific case is excluded).
+     * 3. Matches where all terms are in 'contents', or mixed between 'contents' and 'filename' (as in point 1), are included.
+     *
+     * If this option is disabled (returns false), or for boolean OR queries,
+     * the boolean search will be performed exclusively on the 'contents' field, following the original logic.
+     *
+     * @return True if the filename-content mixed AND search is enabled, false otherwise.
+     */
+    bool isFilenameContentMixedAndSearchEnabled() const;
+
 private:
     SearchOptions &m_options;
 };

--- a/src/dfm-search/dfm-search-client/main.cpp
+++ b/src/dfm-search/dfm-search-client/main.cpp
@@ -463,6 +463,7 @@ int main(int argc, char *argv[])
         contentOptions.setMaxPreviewLength(200);
         contentOptions.setFullTextRetrievalEnabled(true);
         contentOptions.setSearchResultHighlightEnabled(true);
+        contentOptions.setFilenameContentMixedAndSearchEnabled(true);
         if (parser.isSet(maxPreviewOption)) {
             bool ok;
             int previewLength = parser.value(maxPreviewOption).toInt(&ok);

--- a/src/dfm-search/dfm-search-lib/contentsearch/contentsearchapi.cpp
+++ b/src/dfm-search/dfm-search-lib/contentsearch/contentsearchapi.cpp
@@ -47,6 +47,16 @@ bool ContentOptionsAPI::isFullTextRetrievalEnabled() const
     return m_options.customOption("fullTextRetrieval").toBool();
 }
 
+void ContentOptionsAPI::setFilenameContentMixedAndSearchEnabled(bool enabled)
+{
+    m_options.setCustomOption("filenameContentMixedAndSearchEnabled", enabled);
+}
+
+bool ContentOptionsAPI::isFilenameContentMixedAndSearchEnabled() const
+{
+    return m_options.customOption("filenameContentMixedAndSearchEnabled").toBool();
+}
+
 ContentResultAPI::ContentResultAPI(SearchResult &result)
     : m_result(result)
 {

--- a/src/dfm-search/dfm-search-lib/contentsearch/contentstrategies/indexedstrategy.h
+++ b/src/dfm-search/dfm-search-lib/contentsearch/contentstrategies/indexedstrategy.h
@@ -40,6 +40,21 @@ private:
 
     // 构建Lucene查询
     Lucene::QueryPtr buildLuceneQuery(const SearchQuery &query, const Lucene::AnalyzerPtr &analyzer);
+    // Helper for simple queries (original logic for "contents" field)
+    Lucene::QueryPtr buildSimpleContentsQuery(
+            const SearchQuery &query,
+            const Lucene::QueryParserPtr &contentsParser);
+
+    // Helper for "standard" boolean logic (original logic for "contents" field, handles AND/OR)
+    Lucene::QueryPtr buildStandardBooleanContentsQuery(
+            const SearchQuery &query,
+            const Lucene::QueryParserPtr &contentsParser);
+
+    // Helper for "advanced" mixed AND logic (searches "contents" and "filename")
+    Lucene::QueryPtr buildAdvancedAndQuery(
+            const SearchQuery &query,   // Operator is implicitly AND
+            const Lucene::QueryParserPtr &contentsParser,
+            const Lucene::AnalyzerPtr &analyzer);   // Analyzer is needed to create filenameParser
 
     // 处理搜索结果
     void processSearchResults(const Lucene::IndexSearcherPtr &searcher,


### PR DESCRIPTION
… fields

This commit introduces new functionality to enable an extended AND search behavior across 'contents' and 'filename' fields. It adds methods to set and check the status of this feature in the ContentOptionsAPI. The search logic is updated to support this new behavior, allowing for more flexible query handling when both fields are involved. The changes include new helper methods for building queries that accommodate this advanced logic, enhancing the overall search capabilities.

Log: