### PR TITLE
feat: Add isParagraphStart function to determine paragraph beginnings

### DIFF
--- a/src/dfm-search/dfm-search-lib/utils/lucenequeryutils.cpp
+++ b/src/dfm-search/dfm-search-lib/utils/lucenequeryutils.cpp
@@ -10,7 +10,7 @@ namespace LuceneQueryUtils {
 std::wstring getLuceneSpecialChars()
 {
     // Lucene 特殊字符（按 Lucene 语法需要转义）
-    return L"+-&&||!(){}[]^\"~*?:\\/";
+    return L"+-&&||!(){}[]^\"~*?:\\/ ";
 }
 
 Lucene::String processQueryString(const QString &str, bool caseSensitive)
@@ -50,4 +50,4 @@ Lucene::String processQueryString(const QString &str, bool caseSensitive)
 
 }   // namespace LuceneQueryUtils
 
-DFM_SEARCH_END_NS 
+DFM_SEARCH_END_NS


### PR DESCRIPTION
This commit introduces the `isParagraphStart` function, which checks if a given position in the text content marks the start of a paragraph. The function accounts for whitespace and newline characters to accurately identify paragraph boundaries. Additionally, the `customHighlight` function is updated to prepend an ellipsis when the snippet is truncated at a non-paragraph start position, enhancing the text highlighting feature.

Log: