### PR TITLE
Refactor GFile creation and add codec validation for file paths

### DIFF
--- a/include/dfm-io/dfm-io/dfmio_utils.h
+++ b/include/dfm-io/dfm-io/dfmio_utils.h
@@ -59,6 +59,7 @@ public:
     static qint64 deviceBytesFree(const QUrl &url);
     static bool supportTrash(const QUrl &url);
     static bool isGvfsFile(const QUrl &url);
+    static bool isInvalidCodecByPath(const char *path);
 
 private:
     static QMap<QString, QString>

--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -609,9 +609,13 @@ bool DEnumerator::hasNext() const
         g_autofree gchar *path = g_file_get_path(gfile);
         if (path) {
             d->nextUrl = QUrl::fromLocalFile(QString::fromLocal8Bit(path));
+            if (DFMUtils::isInvalidCodecByPath(path))
+                d->nextUrl.setUserInfo("originPath::" + QString::fromLatin1(path));
         } else {
             g_autofree gchar *uri = g_file_get_uri(gfile);
             d->nextUrl = QUrl(QString::fromLocal8Bit(uri));
+            if (DFMUtils::isInvalidCodecByPath(uri))
+                d->nextUrl.setUserInfo("originPath::" + QString::fromLatin1(path));
         }
         d->dfileInfoNext = DLocalHelper::createFileInfoByUri(d->nextUrl, g_file_info_dup(gfileInfo), FILE_DEFAULT_ATTRIBUTES,
                                                              d->enumLinks ? DFileInfo::FileQueryInfoFlags::kTypeNone : DFileInfo::FileQueryInfoFlags::kTypeNoFollowSymlinks);

--- a/src/dfm-io/dfm-io/dfile.cpp
+++ b/src/dfm-io/dfm-io/dfile.cpp
@@ -201,7 +201,7 @@ bool DFilePrivate::doOpen(DFile::OpenFlags mode)
     }
 
     const QUrl &&uri = q->uri();
-    g_autoptr(GFile) gfile = g_file_new_for_uri(uri.toString().toLocal8Bit().data());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(uri);
     g_autoptr(GError) gerror = nullptr;
     checkAndResetCancel();
 
@@ -676,8 +676,7 @@ bool DFile::isOpen() const
 
 qint64 DFile::size() const
 {
-    const QUrl &uri = d->uri;
-    g_autoptr(GFile) gfile = g_file_new_for_uri(uri.toString().toStdString().c_str());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(d->uri);
 
     g_autoptr(GError) gerror = nullptr;
     d->checkAndResetCancel();
@@ -696,8 +695,7 @@ qint64 DFile::size() const
 
 bool DFile::exists() const
 {
-    const QUrl &uri = d->uri;
-    g_autoptr(GFile) gfile = g_file_new_for_uri(uri.toString().toLocal8Bit().data());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(d->uri);
     d->checkAndResetCancel();
     return g_file_query_file_type(gfile, G_FILE_QUERY_INFO_NONE, d->cancellable) != G_FILE_TYPE_UNKNOWN;
 }
@@ -749,7 +747,7 @@ DFile::Permissions DFile::permissions() const
 {
     DFile::Permissions retValue = DFile::Permission::kNoPermission;
 
-    g_autoptr(GFile) gfile = g_file_new_for_uri(d->uri.toString().toStdString().c_str());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(d->uri);
 
     g_autoptr(GError) gerror = nullptr;
     d->checkAndResetCancel();
@@ -908,7 +906,7 @@ bool DFile::setPermissions(Permissions permission)
 {
     quint32 stMode = d->buildPermissions(permission);
 
-    g_autoptr(GFile) gfile = g_file_new_for_uri(d->uri.toString().toStdString().c_str());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(d->uri);
     g_autoptr(GError) gerror = nullptr;
     d->checkAndResetCancel();
     const std::string &attributeKey = DLocalHelper::attributeStringById(DFileInfo::AttributeID::kUnixMode);
@@ -1252,7 +1250,7 @@ DFileFuture *DFile::sizeAsync(int ioPriority, QObject *parent)
     data->me = d.data();
     data->future = future;
 
-    g_autoptr(GFile) gfile = g_file_new_for_uri(d->uri.toString().toStdString().c_str());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(d->uri);
     d->checkAndResetCancel();
     const std::string &attributeKey = DLocalHelper::attributeStringById(DFileInfo::AttributeID::kStandardSize);
     g_file_query_info_async(gfile, attributeKey.c_str(), G_FILE_QUERY_INFO_NONE, ioPriority, d->cancellable, DFilePrivate::sizeAsyncCallback, data);
@@ -1268,7 +1266,7 @@ DFileFuture *DFile::existsAsync(int ioPriority, QObject *parent)
     data->me = d.data();
     data->future = future;
 
-    g_autoptr(GFile) gfile = g_file_new_for_uri(d->uri.toString().toStdString().c_str());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(d->uri);
     d->checkAndResetCancel();
     const std::string &attributeKey = DLocalHelper::attributeStringById(DFileInfo::AttributeID::kStandardType);
     g_file_query_info_async(gfile, attributeKey.c_str(), G_FILE_QUERY_INFO_NONE, ioPriority, d->cancellable, d->existsAsyncCallback, data);
@@ -1284,7 +1282,7 @@ DFileFuture *DFile::permissionsAsync(int ioPriority, QObject *parent)
     data->me = d.data();
     data->future = future;
 
-    g_autoptr(GFile) gfile = g_file_new_for_uri(d->uri.toString().toStdString().c_str());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(d->uri);
     d->checkAndResetCancel();
     const std::string &attributeKey = DLocalHelper::attributeStringById(DFileInfo::AttributeID::kUnixMode);
     g_file_query_info_async(gfile, attributeKey.c_str(), G_FILE_QUERY_INFO_NONE, ioPriority, d->cancellable, d->permissionsAsyncCallback, data);
@@ -1299,7 +1297,7 @@ DFileFuture *DFile::setPermissionsAsync(Permissions permission, int ioPriority, 
     DFileFuture *future = new DFileFuture(parent);
 
     quint32 stMode = d->buildPermissions(permission);
-    g_autoptr(GFile) gfile = g_file_new_for_uri(d->uri.toString().toStdString().c_str());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(d->uri);
     d->checkAndResetCancel();
     g_autoptr(GError) gerror = nullptr;
     const std::string &attributeKey = DLocalHelper::attributeStringById(DFileInfo::AttributeID::kUnixMode);

--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -115,9 +115,7 @@ void DFileInfoPrivate::initNormal()
         return;
 
     const QUrl &url = q->uri();
-    const QString &urlStr = url.toString();
-
-    this->gfile = g_file_new_for_uri(urlStr.toLocal8Bit().data());
+    this->gfile = DLocalHelper::createGFile(url);;
 }
 
 void DFileInfoPrivate::attributeExtend(DFileInfo::MediaType type, QList<DFileInfo::AttributeExtendID> ids, DFileInfo::AttributeExtendFuncCallback callback)

--- a/src/dfm-io/dfm-io/dfmio_utils.cpp
+++ b/src/dfm-io/dfm-io/dfmio_utils.cpp
@@ -39,7 +39,7 @@ QString DFMUtils::devicePathFromUrl(const QUrl &url)
     if (!url.isValid())
         return QString();
 
-    g_autoptr(GFile) gfile = g_file_new_for_uri(url.toString().toStdString().c_str());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(url);
     g_autoptr(GError) gerror = nullptr;
     g_autoptr(GMount) gmount = g_file_find_enclosing_mount(gfile, nullptr, &gerror);
     if (gmount) {
@@ -59,7 +59,7 @@ QString DFMUtils::deviceNameFromUrl(const QUrl &url)
     if (!url.isValid())
         return QString();
 
-    g_autoptr(GFile) gfile = g_file_new_for_uri(url.toString().toStdString().c_str());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(url);
     g_autoptr(GUnixMountEntry) mount = g_unix_mount_for(g_file_peek_path(gfile), nullptr);
     if (mount)
         return QString::fromLocal8Bit(g_unix_mount_get_device_path(mount));
@@ -71,7 +71,7 @@ QString DFMUtils::fsTypeFromUrl(const QUrl &url)
     if (!url.isValid())
         return QString();
 
-    g_autoptr(GFile) gfile = g_file_new_for_uri(url.toString().toLocal8Bit().data());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(url);
     g_autofree char *path = g_file_get_path(gfile);
     if (!path)
         return QString();
@@ -86,7 +86,7 @@ QString DFMUtils::mountPathFromUrl(const QUrl &url)
     if (!url.isValid())
         return QString();
 
-    g_autoptr(GFile) gfile = g_file_new_for_uri(url.toString().toLocal8Bit().data());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(url);
     g_autofree char *path = g_file_get_path(gfile);
     if (!path)
         return QString();
@@ -108,7 +108,7 @@ QUrl DFMUtils::directParentUrl(const QUrl &url, const bool localFirst /*= true*/
         return QUrl();
     };
 
-    g_autoptr(GFile) file = g_file_new_for_uri(url.toString().toLocal8Bit().data());
+    g_autoptr(GFile) file = DLocalHelper::createGFile(url);
     g_autoptr(GFile) fileParent = g_file_get_parent(file);
     if (fileParent) {
         if (localFirst) {
@@ -128,7 +128,7 @@ bool DFMUtils::fileIsRemovable(const QUrl &url)
 {
     if (!url.isValid())
         return false;
-    g_autoptr(GFile) gfile = g_file_new_for_uri(url.toString().toLocal8Bit().data());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(url);
     g_autoptr(GMount) gmount = g_file_find_enclosing_mount(gfile, nullptr, nullptr);
     if (gmount) {
         g_autoptr(GDrive) gdrive = g_mount_get_drive(gmount);
@@ -323,7 +323,7 @@ bool dfmio::DFMUtils::supportTrash(const QUrl &url)
     if (file_stat.st_dev == home_stat.st_dev)
         return true;
 
-    g_autoptr(GFile) gfile = g_file_new_for_uri(url.toString().toLocal8Bit().data());
+    g_autoptr(GFile) gfile = DLocalHelper::createGFile(url);
     g_autofree char *path1 = g_file_get_path(gfile);
     if (!path1)
         return false;
@@ -345,6 +345,15 @@ bool DFMUtils::isGvfsFile(const QUrl &url)
     QRegularExpression re { gvfsMatch };
     QRegularExpressionMatch match { re.match(path) };
     return match.hasMatch();
+}
+
+bool DFMUtils::isInvalidCodecByPath(const char *path)
+{
+    QTextCodec::ConverterState stat;
+    auto codec = QTextCodec::codecForLocale();
+
+    auto str = codec->toUnicode(path, static_cast<int>(strlen(path)), &stat);
+    return stat.invalidChars;
 }
 
 QMap<QString, QString> DFMUtils::fstabBindInfo()

--- a/src/dfm-io/dfm-io/doperator.cpp
+++ b/src/dfm-io/dfm-io/doperator.cpp
@@ -42,7 +42,7 @@ void DOperatorPrivate::setErrorFromGError(GError *gerror)
 
 GFile *DOperatorPrivate::makeGFile(const QUrl &url)
 {
-    return g_file_new_for_uri(url.toString().toLocal8Bit().data());
+    return DLocalHelper::createGFile(url);
 }
 
 void DOperatorPrivate::checkAndResetCancel()

--- a/src/dfm-io/dfm-io/dwatcher.cpp
+++ b/src/dfm-io/dfm-io/dwatcher.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <dfm-io/dwatcher.h>
+#include "utils/dlocalhelper.h"
 
 #include "private/dwatcher_p.h"
 
@@ -184,7 +185,7 @@ bool DWatcher::start(int timeRate)
     if (uri.scheme() == "file" && uri.path() == "/")
         url.append("/");
 
-    d->gfile = g_file_new_for_uri(url.toStdString().c_str());
+    d->gfile = DLocalHelper::createGFile(url);
 
     d->gmonitor = d->createMonitor(d->gfile, d->type);
 

--- a/src/dfm-io/dfm-io/utils/dlocalhelper.h
+++ b/src/dfm-io/dfm-io/utils/dlocalhelper.h
@@ -70,6 +70,7 @@ public:
     static int compareByLastRead(const FTSENT **left, const FTSENT **right);
     static QSharedPointer<DEnumerator::SortFileInfo> createSortFileInfo(const FTSENT *ent,
                                                                         const QSet<QString> hidList);
+    static GFile* createGFile(const QUrl &uri);
 private:
     static QVariant getGFileInfoIcon(GFileInfo *gfileinfo, const char *key, DFMIOErrorCode &errorcode);
     static QVariant getGFileInfoString(GFileInfo *gfileinfo, const char *key, DFMIOErrorCode &errorcode);

--- a/src/dfm-io/tools/dfm-copy-gio.cpp
+++ b/src/dfm-io/tools/dfm-copy-gio.cpp
@@ -24,8 +24,8 @@ static void err_msg(const char *msg)
 
 static void copy(const QString &sourcePath, const QString &destPath)
 {
-    GFile *gfileSource = g_file_new_for_uri(sourcePath.toLocal8Bit().data());
-    GFile *gfileDest = g_file_new_for_uri(destPath.toLocal8Bit().data());
+    GFile *gfileSource = DLocalHelper::createGFile(sourcePath);
+    GFile *gfileDest = DLocalHelper::createGFile(destPath);
 
     GFile *gfileTarget = nullptr;
     if (DLocalHelper::checkGFileType(gfileDest, G_FILE_TYPE_DIRECTORY)) {
@@ -33,7 +33,7 @@ static void copy(const QString &sourcePath, const QString &destPath)
         gfileTarget = g_file_get_child(gfileDest, basename);
         g_free(basename);
     } else {
-        gfileTarget = g_file_new_for_uri(destPath.toLocal8Bit().data());
+        gfileTarget = DLocalHelper::createGFile(destPath);
     }
 
     //预先读取

--- a/src/dfm-io/tools/dfm-copy3.cpp
+++ b/src/dfm-io/tools/dfm-copy3.cpp
@@ -53,8 +53,8 @@ static void copy(const QString &url_src, const QString &url_dst)
     int read = 0;
 
     GError *gerror = nullptr;
-    GFile *gfileSource = g_file_new_for_uri(url_src.toLocal8Bit().data());
-    GFile *gfileDest = g_file_new_for_uri(url_dst.toLocal8Bit().data());
+    GFile *gfileSource =DLocalHelper::createGFile(url_src);
+    GFile *gfileDest = DLocalHelper::createGFile(url_dst);
 
     GFile *gfileTarget = nullptr;
     if (DLocalHelper::checkGFileType(gfileDest, G_FILE_TYPE_DIRECTORY)) {
@@ -62,7 +62,7 @@ static void copy(const QString &url_src, const QString &url_dst)
         gfileTarget = g_file_get_child(gfileDest, basename);
         g_free(basename);
     } else {
-        gfileTarget = g_file_new_for_uri(url_dst.toLocal8Bit().data());
+        gfileTarget = DLocalHelper::createGFile(url_dst);
     }
 
     GFileInputStream *inputStream = g_file_read(gfileSource, nullptr, &gerror);


### PR DESCRIPTION
- Introduced DLocalHelper::createGFile to centralize GFile creation from QUrl or path, replacing direct g_file_new_for_uri/g_file_new_for_path calls throughout the codebase.
- Updated DFile, DFileInfo, DEnumerator, DOperator, DWatcher, DFMUtils, and related tools to use the new helper for improved consistency and maintainability.
- Added DFMUtils::isUnvalidCodecByPath to check for invalid codec in file paths, and integrated this check in DEnumerator and DLocalHelper to set userInfo in QUrl when necessary.
- Improved symlink handling in DLocalHelper::createSortFileInfo to use fromLocal8Bit for target paths.
- Enhanced robustness and code clarity in file operations and path handling.

Log: Refactor GFile creation and add codec validation for file paths
Bug: https://pms.uniontech.com//bug-view-315953.html