### PR TITLE
fix: Address memory leaks and resource management in DEnumerator and DFile classes

### DIFF
--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -430,6 +430,7 @@ void DEnumeratorPrivate::enumUriAsyncCallBack(GObject *sourceObject, GAsyncResul
     EnumUriData *data = static_cast<EnumUriData *>(userData);
     if (!data || !data->pointer || data->pointer->asyncStoped) {
         qInfo() << "user data error " << data;
+        delete data;  // 修复内存泄漏：在错误情况下删除 data
         return;
     }
 
@@ -444,6 +445,7 @@ void DEnumeratorPrivate::enumUriAsyncCallBack(GObject *sourceObject, GAsyncResul
 
     if (enumerator == nullptr || error) {
         data->pointer->enumUriAsyncOvered(nullptr);
+        delete data;  // 修复内存泄漏：在错误情况下删除 data
     } else {
         data->enumerator = enumerator;
         data->pointer->checkAndResetCancel();
@@ -467,6 +469,7 @@ void DEnumeratorPrivate::moreFilesCallback(GObject *sourceObject, GAsyncResult *
     EnumUriData *data = static_cast<EnumUriData *>(userData);
     if (!data || !data->pointer || data->pointer->asyncStoped) {
         qInfo() << "user data error " << data;
+        delete data;  // 修复内存泄漏：在错误情况下删除 data
         return;
     }
 
@@ -495,6 +498,7 @@ void DEnumeratorPrivate::moreFilesCallback(GObject *sourceObject, GAsyncResult *
         }
         g_object_unref(data->enumerator);
         data->enumerator = nullptr;
+        delete data;  // 修复内存泄漏：在异步操作结束时删除 data
     }
 
     if (error)

--- a/src/dfm-io/dfm-io/dfile.cpp
+++ b/src/dfm-io/dfm-io/dfile.cpp
@@ -26,6 +26,29 @@ DFilePrivate::DFilePrivate(DFile *q)
 {
 }
 
+DFilePrivate::~DFilePrivate()
+{
+    // 确保 cancellable 资源被正确清理
+    if (cancellable) {
+        g_object_unref(cancellable);
+        cancellable = nullptr;
+    }
+    
+    // 清理其他 GObject 资源
+    if (iStream) {
+        g_object_unref(iStream);
+        iStream = nullptr;
+    }
+    if (oStream) {
+        g_object_unref(oStream);
+        oStream = nullptr;
+    }
+    if (ioStream) {
+        g_object_unref(ioStream);
+        ioStream = nullptr;
+    }
+}
+
 void DFilePrivate::setError(DFMIOError error)
 {
     this->error = error;

--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -401,8 +401,12 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
         return QVariant(ret);
     }
     case DFileInfo::AttributeID::kOriginalUri:
-        if (gfile)
-            return QUrl(g_file_get_uri(gfile));
+        if (gfile) {
+            gchar *uri_str = g_file_get_uri(gfile);
+            QUrl url = QUrl(QString::fromUtf8(uri_str));
+            g_free(uri_str);
+            return url;
+        }
         return uri;
     default:
         return retValue;

--- a/src/dfm-io/dfm-io/private/dfile_p.h
+++ b/src/dfm-io/dfm-io/private/dfile_p.h
@@ -61,6 +61,7 @@ public:
 
 public:
     explicit DFilePrivate(DFile *q);
+    ~DFilePrivate();
     void setError(DFMIOError error);
     void setErrorFromGError(GError *gerror);
     void checkAndResetCancel();

--- a/src/dfm-mount/private/dnetworkmounter.cpp
+++ b/src/dfm-mount/private/dnetworkmounter.cpp
@@ -114,7 +114,7 @@ QList<QVariantMap> DNetworkMounter::loginPasswd(const QString &address)
                                                      nullptr, &err);
     while (items) {
         auto item = static_cast<SecretItem *>(items->data);
-        GHashTable_autoptr itemAttrs = secret_item_get_attributes(item);
+        GHashTable *itemAttrs = secret_item_get_attributes(item);
         QVariantMap attr;
         g_hash_table_foreach(
                 itemAttrs,
@@ -131,6 +131,10 @@ QList<QVariantMap> DNetworkMounter::loginPasswd(const QString &address)
             passwds.append(attr);
         else
             qInfo() << "got invalid saved keyring, ignore." << attr;
+
+        // 手动释放 GHashTable 以避免内存泄漏
+        if (itemAttrs)
+            g_hash_table_unref(itemAttrs);
 
         items = items->next;
     }


### PR DESCRIPTION

This commit resolves memory leaks by ensuring proper deletion of user data in the `DEnumeratorPrivate::enumUriAsyncCallBack` and `DEnumeratorPrivate::moreFilesCallback` methods. Additionally, the `DFilePrivate` destructor is implemented to clean up GObject resources, including `cancellable`, `iStream`, `oStream`, and `ioStream`. These changes enhance resource management and stability across the affected classes.

Log: fix some memory leaks issue
Bug: https://pms.uniontech.com/bug-view-316919.html