### PR TITLE
fix: add OperatorsFileUtils for delayed removal of copying file URLs

### DIFF
--- a/src/dfm-io/dfm-io/private/denumerator_p.h
+++ b/src/dfm-io/dfm-io/private/denumerator_p.h
@@ -55,6 +55,8 @@ public:
     bool hasNext();
     QList<QSharedPointer<DFileInfo>> fileInfoList();
     void setQueryAttributes(const QString &attributes);
+    char *filePath(const QUrl &url);
+    QUrl buildUrl(const QUrl &url, const char *fileName);
 
     static void enumUriAsyncCallBack(GObject *sourceObject,
                                      GAsyncResult *res,


### PR DESCRIPTION
- Introduced OperatorsFileUtils singleton class with delayRemoveCopyingFile method to delay the removal of copying file URLs by 500ms.
- Updated FileOperateBaseWorker to use OperatorsFileUtils::delayRemoveCopyingFile instead of direct FileUtils::removeCopyingFileUrl calls.
- Enhances safety and reliability of file operations by preventing premature removal of file URLs.

Log: add OperatorsFileUtils for delayed removal of copying file URLs
Bug: https://pms.uniontech.com//bug-view-315953.html