### PR TITLE
fix: Add statvfs-based free size calculation in DBlockDevicePrivate::sizeFree

### DIFF
--- a/src/dfm-mount/lib/dblockdevice.cpp
+++ b/src/dfm-mount/lib/dblockdevice.cpp
@@ -12,6 +12,7 @@
 #include <QDebug>
 
 #include <functional>
+#include <sys/statvfs.h>
 
 extern "C" {
 #include <udisks/udisks.h>
@@ -1066,6 +1067,14 @@ qint64 DBlockDevicePrivate::sizeFree() const
         return 0;
     }
     auto mpt = mpts.first();
+
+    struct statvfs fsInfo;
+    int ok = statvfs(mpt.toStdString().c_str(), &fsInfo);
+    if (ok == 0) {
+        const quint64 blksize = quint64(fsInfo.f_bsize);
+        return static_cast<qint64>(fsInfo.f_bavail * blksize);
+    }
+
     QStorageInfo info(mpt);
     return info.bytesAvailable();
 }


### PR DESCRIPTION
- Included <sys/statvfs.h> and implemented logic to use statvfs for retrieving filesystem statistics in sizeFree().
- If statvfs succeeds, the free size is calculated using block counts and block size, with a debug message output.
- Falls back to QStorageInfo if statvfs fails.
- Improves accuracy and robustness of free space calculation for block devices.

Log: Add statvfs-based free size calculation in DBlockDevicePrivate::sizeFree
Bug: https://pms.uniontech.com/bug-view-316953.html