### PR TITLE
fix: Correct GUnixMountEntry type usage in DProtocolMonitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ debian/libdfm-burn-dev/*
 debian/*.log
 debian/*.substvars
 debian/files
+.cursor
 

--- a/src/dfm-mount/lib/dprotocolmonitor.cpp
+++ b/src/dfm-mount/lib/dprotocolmonitor.cpp
@@ -330,7 +330,7 @@ bool DProtocolMonitorPrivate::isNativeMount(const QString &mpt)
         return false;
 
     std::string s = mpt.toStdString();
-    GUnixMountEntry_autoptr entry = g_unix_mount_for(s.data(), nullptr);
+    g_autoptr(GUnixMountEntry) entry = g_unix_mount_for(s.data(), nullptr);
     if (entry) {
         QString devPath = g_unix_mount_get_device_path(entry);
         if (devPath.startsWith("/dev/"))


### PR DESCRIPTION
This commit updates the type declaration for `entry` in the `DProtocolMonitorPrivate::isNativeMount` method from `GUnixMountEntry_autoptr` to `g_autoptr(GUnixMountEntry)`, ensuring proper memory management and alignment with GObject conventions. Additionally, a new entry for `.cursor` is added to the `.gitignore` file to prevent tracking of cursor files.

Log: Correct GUnixMountEntry type usage in DProtocolMonitor
Bug: https://pms.uniontech.com/bug-view-316919.html