### PR TITLE
feat: add Boost and Threads dependencies to dfm-search library

### DIFF
--- a/misc/dfm-search/dfm-search.pc.in
+++ b/misc/dfm-search/dfm-search.pc.in
@@ -2,7 +2,7 @@ Name: @BIN_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@
 URL: @CMAKE_PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Requires: Qt@QT_VERSION_MAJOR@Core dtk@DFM_VERSION_MAJOR@core liblucene++ liblucene++-contrib
+Requires: Qt@QT_VERSION_MAJOR@Core dtk@DFM_VERSION_MAJOR@core liblucene++ liblucene++-contrib Boostsystem Threads
 Cflags: -I"@CMAKE_INSTALL_FULL_INCLUDEDIR@/@BIN_NAME@"
 Libs: -L"@CMAKE_INSTALL_FULL_LIBDIR@" -l@BIN_NAME@
 Libs.private: -L"@CMAKE_INSTALL_FULL_LIBDIR@" -l@BIN_NAME@ 

--- a/misc/dfm-search/dfm-searchConfig.cmake.in
+++ b/misc/dfm-search/dfm-searchConfig.cmake.in
@@ -3,6 +3,8 @@ include(CMakeFindDependencyMacro)
 # 添加必要的依赖
 find_dependency(Qt@QT_VERSION_MAJOR@ COMPONENTS Core)
 find_dependency(Dtk@DFM_VERSION_MAJOR@ COMPONENTS Core)
+find_dependency(Threads)
+find_dependency(Boost COMPONENTS system)
 
 # 查找 PkgConfig 和 liblucene++ 依赖
 find_dependency(PkgConfig)

--- a/src/dfm-search/dfm-search-lib/dfm-search.cmake
+++ b/src/dfm-search/dfm-search-lib/dfm-search.cmake
@@ -1,6 +1,8 @@
 # Setup the environment
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
 find_package(Dtk${DFM_VERSION_MAJOR} COMPONENTS Core REQUIRED)
+find_package(Threads REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(Lucene REQUIRED IMPORTED_TARGET liblucene++ liblucene++-contrib)
@@ -11,10 +13,12 @@ add_library(${BIN_NAME} SHARED
             ${SRCS}
 )
 
-target_link_libraries(${BIN_NAME}
+target_link_libraries(${BIN_NAME} PUBLIC
     Qt${QT_VERSION_MAJOR}::Core
     Dtk${DFM_VERSION_MAJOR}::Core
     PkgConfig::Lucene
+    Threads::Threads
+    Boost::system
 )
 
 target_include_directories(
@@ -43,7 +47,7 @@ set_target_properties(
 )
 
 # Install with export
-install(TARGETS ${BIN_NAME} 
+install(TARGETS ${BIN_NAME}
     EXPORT ${BIN_NAME}Targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -75,4 +79,4 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}.pc DESTINATION ${CMAKE_INS
 
 # config cmake file
 configure_file(${PROJECT_SOURCE_DIR}/misc/${BASE_NAME}/${BASE_NAME}Config.cmake.in ${BIN_NAME}Config.cmake @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}Config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${BIN_NAME}) 
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}Config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${BIN_NAME})


### PR DESCRIPTION
- Add Boost::system and Threads::Threads to target_link_libraries
- Include find_dependency calls for Threads and Boost in Config.cmake.in
- Update pkg-config file to include Boost and Threads requirements
- Change target_link_libraries visibility from default to PUBLIC
- Fix minor formatting issues in install commands

This change ensures proper linking and dependency resolution for the dfm-search library when using Boost system components and multithreading capabilities.

Log: add Boost and Threads dependencies to dfm-search library
Task: https://pms.uniontech.com/task-view-377717.html