### PR TITLE
feat: Introduce batch processing time configuration for search results

### DIFF
--- a/include/dfm-search/dfm-search/searchoptions.h
+++ b/include/dfm-search/dfm-search/searchoptions.h
@@ -197,6 +197,27 @@ public:
      */
     int syncSearchTimeout() const;
 
+    /**
+     * @brief Sets the batch processing time interval in milliseconds.
+     *
+     * This controls how frequently search results are batched and emitted during
+     * asynchronous search operations. A larger interval reduces the frequency of
+     * signal emissions but may make the UI feel less responsive. A smaller interval
+     * provides more responsive updates but may impact performance with high result volumes.
+     *
+     * @param milliseconds Batch time interval in milliseconds (minimum 50, maximum 5000)
+     * @sa batchTime()
+     */
+    void setBatchTime(int milliseconds);
+
+    /**
+     * @brief Returns the current batch processing time interval in milliseconds.
+     *
+     * @return Batch time interval in milliseconds (default is 1000)
+     * @sa setBatchTime()
+     */
+    int batchTime() const;
+
 private:
     std::unique_ptr<SearchOptionsData> d;   // PIMPL
 };

--- a/src/dfm-search/dfm-search-lib/core/genericsearchengine.cpp
+++ b/src/dfm-search/dfm-search-lib/core/genericsearchengine.cpp
@@ -11,7 +11,7 @@
 DFM_SEARCH_BEGIN_NS
 DCORE_USE_NAMESPACE
 
-constexpr int kDefaultBatchTime = 100;   // 100ms
+constexpr int kDefaultBatchTime = 1000;   // 1000ms
 
 GenericSearchEngine::GenericSearchEngine(QObject *parent)
     : AbstractSearchEngine(parent),
@@ -72,6 +72,9 @@ SearchOptions GenericSearchEngine::searchOptions() const
 void GenericSearchEngine::setSearchOptions(const SearchOptions &options)
 {
     m_options = options;
+    
+    // 更新批处理定时器间隔
+    m_batchTimer.setInterval(m_options.batchTime());
 }
 
 SearchStatus GenericSearchEngine::status() const
@@ -93,6 +96,7 @@ void GenericSearchEngine::search(const SearchQuery &query)
 
     // 清空批处理结果并启动定时器
     m_batchResults.clear();
+    m_batchTimer.setInterval(m_options.batchTime());
     m_batchTimer.start();
 
     // 保存当前查询

--- a/src/dfm-search/dfm-search-lib/core/searchoptions.cpp
+++ b/src/dfm-search/dfm-search-lib/core/searchoptions.cpp
@@ -161,4 +161,20 @@ int SearchOptions::syncSearchTimeout() const
     return d->syncSearchTimeoutSecs;
 }
 
+void SearchOptions::setBatchTime(int milliseconds)
+{
+    // 限制批处理时间范围在 50ms 到 5000ms 之间
+    if (milliseconds < 50) {
+        milliseconds = 50;
+    } else if (milliseconds > 5000) {
+        milliseconds = 5000;
+    }
+    d->batchTimeMs = milliseconds;
+}
+
+int SearchOptions::batchTime() const
+{
+    return d->batchTimeMs;
+}
+
 DFM_SEARCH_END_NS

--- a/src/dfm-search/dfm-search-lib/core/searchoptionsdata.h
+++ b/src/dfm-search/dfm-search-lib/core/searchoptionsdata.h
@@ -36,6 +36,7 @@ public:
     bool resultFoundEnabled;   ///< Whether to enable result found notifications
     bool detailedResultsEnabled;   ///< Whether to include detailed information in search results
     int syncSearchTimeoutSecs { 60 };
+    int batchTimeMs { 1000 };   ///< Batch processing time interval in milliseconds
 };
 
 DFM_SEARCH_END_NS


### PR DESCRIPTION
This commit adds functionality to set and retrieve the batch processing time interval for asynchronous search operations. The new methods `setBatchTime(int milliseconds)` and `batchTime() const` are implemented in the `SearchOptions` class, allowing users to control the frequency of search result emissions. The default batch time is updated to 1000 milliseconds, and the interval is enforced between 50 and 5000 milliseconds. This enhancement improves the responsiveness of the UI during search operations while allowing for performance optimization based on user preferences.

Log: