### PR TITLE
feat: add configurable batch processing time for search results

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,8 @@ Build-Depends:
  libmediainfo-dev,
  libsecret-1-dev,
  liblucene++-dev,
- libboost-filesystem-dev
+ libboost-filesystem-dev,
+ libboost-system-dev
 Standards-Version: 4.3.0
 Homepage: http://www.deepin.org
 #Vcs-Browser: https://salsa.debian.org/debian/util-dfm

--- a/include/dfm-search/dfm-search/searchoptions.h
+++ b/include/dfm-search/dfm-search/searchoptions.h
@@ -199,6 +199,27 @@ public:
      */
     int syncSearchTimeout() const;
 
+    /**
+     * @brief Sets the batch processing time interval in milliseconds.
+     *
+     * This controls how frequently search results are batched and emitted during
+     * asynchronous search operations. A larger interval reduces the frequency of
+     * signal emissions but may make the UI feel less responsive. A smaller interval
+     * provides more responsive updates but may impact performance with high result volumes.
+     *
+     * @param milliseconds Batch time interval in milliseconds (minimum 50, maximum 5000)
+     * @sa batchTime()
+     */
+    void setBatchTime(int milliseconds);
+
+    /**
+     * @brief Returns the current batch processing time interval in milliseconds.
+     *
+     * @return Batch time interval in milliseconds (default is 1000)
+     * @sa setBatchTime()
+     */
+    int batchTime() const;
+
 private:
     std::unique_ptr<SearchOptionsData> d;   // PIMPL
 };

--- a/src/dfm-search/dfm-search-lib/core/genericsearchengine.cpp
+++ b/src/dfm-search/dfm-search-lib/core/genericsearchengine.cpp
@@ -11,7 +11,7 @@
 DFM_SEARCH_BEGIN_NS
 DCORE_USE_NAMESPACE
 
-constexpr int kDefaultBatchTime = 100;   // 100ms
+constexpr int kDefaultBatchTime = 1000;   // 1000ms
 
 GenericSearchEngine::GenericSearchEngine(QObject *parent)
     : AbstractSearchEngine(parent),
@@ -78,6 +78,8 @@ SearchOptions GenericSearchEngine::searchOptions() const
 void GenericSearchEngine::setSearchOptions(const SearchOptions &options)
 {
     m_options = options;
+    // 更新批处理定时器间隔
+    m_batchTimer.setInterval(m_options.batchTime());
 }
 
 SearchStatus GenericSearchEngine::status() const
@@ -99,6 +101,7 @@ void GenericSearchEngine::search(const SearchQuery &query)
 
     // 清空批处理结果并启动定时器
     m_batchResults.clear();
+    m_batchTimer.setInterval(m_options.batchTime());
     m_batchTimer.start();
 
     // 保存当前查询

--- a/src/dfm-search/dfm-search-lib/core/searchoptions.cpp
+++ b/src/dfm-search/dfm-search-lib/core/searchoptions.cpp
@@ -161,4 +161,20 @@ int SearchOptions::syncSearchTimeout() const
     return d->syncSearchTimeoutSecs;
 }
 
+void SearchOptions::setBatchTime(int milliseconds)
+{
+    // 限制批处理时间范围在 50ms 到 5000ms 之间
+    if (milliseconds < 50) {
+        milliseconds = 50;
+    } else if (milliseconds > 5000) {
+        milliseconds = 5000;
+    }
+    d->batchTimeMs = milliseconds;
+}
+
+int SearchOptions::batchTime() const
+{
+    return d->batchTimeMs;
+}
+
 DFM_SEARCH_END_NS

--- a/src/dfm-search/dfm-search-lib/core/searchoptionsdata.h
+++ b/src/dfm-search/dfm-search-lib/core/searchoptionsdata.h
@@ -36,6 +36,7 @@ public:
     bool resultFoundEnabled;   ///< Whether to enable result found notifications
     bool detailedResultsEnabled;   ///< Whether to include detailed information in search results
     int syncSearchTimeoutSecs { 60 };
+    int batchTimeMs { 1000 }; ///< Batch processing time interval in milliseconds
 };
 
 DFM_SEARCH_END_NS


### PR DESCRIPTION
- Add batchTime() and setBatchTime() methods to SearchOptions class
- Implement batch time configuration with validation (50-5000ms range)
- Update GenericSearchEngine to use configurable batch time interval
- Change default batch time from 100ms to 1000ms for better performance
- Add libboost-system-dev dependency to debian/control for system components
- Add batchTimeMs field to SearchOptionsData with 1000ms default value

This change allows fine-tuning of search result batching frequency, improving performance for high-volume searches while maintaining UI responsiveness. The configurable interval helps balance between update frequency and system performance.

Log: add configurable batch processing time for search results
Task: https://pms.uniontech.com/task-view-377717.html