### PR TITLE
fix: Update index readiness check to allow for multiple valid statuses

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+util-dfm (1.3.31) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 27 Jun 2025 16:15:42 +0800
+
 util-dfm (1.3.30) unstable; urgency=medium
 
   * Enhance index availability checks and introduce readiness validation 

--- a/src/dfm-search/dfm-search-lib/utils/searchutility.cpp
+++ b/src/dfm-search/dfm-search-lib/utils/searchutility.cpp
@@ -541,10 +541,11 @@ bool isFileNameIndexReadyForSearch()
         return false;
     }
 
+    const QStringList &validStatus = { "scanning", "monitoring" };
     const QString &status = currentStatus.value();
-    if (status != "monitoring") {
+    if (!validStatus.contains(status)) {
         qDebug() << "Index status is '" << status
-                 << "', expected 'monitoring'. Index not ready for search.";
+                 << "', expected 'scanning' or 'monitoring'. Index not ready for search.";
         return false;
     }
 


### PR DESCRIPTION
This commit modifies the `isFileNameIndexReadyForSearch` function to check if the index status is either "scanning" or "monitoring" instead of just "monitoring". This change improves the flexibility of the index readiness validation, ensuring that the search can proceed under more conditions while providing clearer debug output regarding the expected status.

Log: