### PR TITLE
fix: improve index status validation to accept both scanning and monitoring states

### DIFF
--- a/src/dfm-search/dfm-search-lib/utils/searchutility.cpp
+++ b/src/dfm-search/dfm-search-lib/utils/searchutility.cpp
@@ -543,11 +543,11 @@ bool isFileNameIndexReadyForSearch()
         return false;
     }
 
+    const QStringList &validStatus = { "scanning", "monitoring" };
     const QString &status = currentStatus.value();
-    if (status != "monitoring") {
+    if (!validStatus.contains(status)) {
         qDebug() << "Index status is '" << status
-                 << "', expected 'monitoring'. Index not ready for search.";
-        return false;
+                 << "', expected 'scanning' or 'monitoring'. Index not ready for search.";
     }
 
     return true;


### PR DESCRIPTION
- Update isFileNameIndexReadyForSearch() to accept "scanning" status in addition to "monitoring"
- Replace hardcoded status check with a list of valid statuses
- Update debug message to reflect the new acceptable status values
- Use contains() method for cleaner status validation logic

This change allows search operations to proceed when the index is in scanning state, improving user experience by reducing unnecessary search blocking during index updates.

Log: improve index status validation to accept both scanning and monitoring states
Task: https://pms.uniontech.com/task-view-377717.html