### PR TITLE
fix: improve symlink handling and file size calculation in DLocalHelper

### DIFF
--- a/include/dfm-io/dfm-io/dfmio_utils.h
+++ b/include/dfm-io/dfm-io/dfmio_utils.h
@@ -58,6 +58,7 @@ public:
     static int syncTrashCount();
     static qint64 deviceBytesFree(const QUrl &url);
     static bool supportTrash(const QUrl &url);
+    static bool isGvfsFile(const QUrl &url);
 
 private:
     static QMap<QString, QString>

--- a/src/dfm-io/dfm-io/dfmio_utils.cpp
+++ b/src/dfm-io/dfm-io/dfmio_utils.cpp
@@ -334,6 +334,19 @@ bool dfmio::DFMUtils::supportTrash(const QUrl &url)
     return true;
 }
 
+bool DFMUtils::isGvfsFile(const QUrl &url)
+{
+    if (!url.isValid())
+        return false;
+
+    const QString &path = url.toLocalFile();
+    static const QString *gvfsMatch = new QString{ "(^/run/user/\\d+/gvfs/|^/root/.gvfs/|^/media/[\\s\\S]*/smbmounts)" };
+    // TODO(xust) /media/$USER/smbmounts might be changed in the future.
+    QRegularExpression re { *gvfsMatch };
+    QRegularExpressionMatch match { re.match(path) };
+    return match.hasMatch();
+}
+
 QMap<QString, QString> DFMUtils::fstabBindInfo()
 {
     static QMutex mutex;

--- a/src/dfm-io/dfm-io/utils/dlocalhelper.h
+++ b/src/dfm-io/dfm-io/utils/dlocalhelper.h
@@ -87,6 +87,9 @@ private:
     static bool setGFileInfoInt32(GFile *gfile, const char *key, const QVariant &value, GError **gerror);
     static bool setGFileInfoUint64(GFile *gfile, const char *key, const QVariant &value, GError **gerror);
     static bool setGFileInfoInt64(GFile *gfile, const char *key, const QVariant &value, GError **gerror);
+    static QString symlinkTarget(const QUrl &url);
+    static QString resolveSymlink(const QUrl &url);
+    static qint64 fileSizeByEnt(const FTSENT **ent);
 };
 
 END_IO_NAMESPACE


### PR DESCRIPTION
- Add symlinkTarget() and resolveSymlink() helpers to resolve symlink chains and detect cycles
- Add fileSizeByEnt() to correctly determine file size for symlinks, including chained symlinks
- Update compareBySize() to use fileSizeByEnt() for accurate sorting
- Refactor createSortFileInfo() to use resolveSymlink() for symlink targets and update file size and isDir accordingly
- Fix stat usage to handle UTF-8 paths and improve symlink resolution logic
- Ensure isDir and isFile are set correctly for symlinks and their targets

These changes improve the accuracy of file size and type detection for symlinks, especially when sorting or displaying file information.

Log: improve symlink handling and file size calculation in DLocalHelper Bug: