### PR TITLE
fix: improve symlink handling and file size calculation in DLocalHelper

### DIFF
--- a/src/dfm-io/dfm-io/utils/dlocalhelper.h
+++ b/src/dfm-io/dfm-io/utils/dlocalhelper.h
@@ -87,6 +87,9 @@ private:
     static bool setGFileInfoInt32(GFile *gfile, const char *key, const QVariant &value, GError **gerror);
     static bool setGFileInfoUint64(GFile *gfile, const char *key, const QVariant &value, GError **gerror);
     static bool setGFileInfoInt64(GFile *gfile, const char *key, const QVariant &value, GError **gerror);
+    static QString symlinkTarget(const QUrl &url);
+    static QString resolveSymlink(const QUrl &url);
+    static qint64 fileSizeByEnt(const FTSENT **ent);
 };
 
 END_IO_NAMESPACE


### PR DESCRIPTION
- Add symlinkTarget() and resolveSymlink() helpers to resolve symlink chains and detect cycles
- Add fileSizeByEnt() to correctly determine file size for symlinks, including chained symlinks
- Update compareBySize() to use fileSizeByEnt() for accurate sorting
- Refactor createSortFileInfo() to use resolveSymlink() for symlink targets and update file size and isDir accordingly
- Fix stat usage to handle UTF-8 paths and improve symlink resolution logic
- Ensure isDir and isFile are set correctly for symlinks and their targets

These changes improve the accuracy of file size and type detection for symlinks, especially when sorting or displaying file information.

Log: improve symlink handling and file size calculation in DLocalHelper Bug: