### PR TITLE
chore: Update cmake minimum version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.7)
 
 project(util-dfm)
 

--- a/src/dfm-burn/dfm-burn-client/CMakeLists.txt
+++ b/src/dfm-burn/dfm-burn-client/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.7)
 
 project(dfm${DFM_VERSION_MAJOR}-burn-client)
 

--- a/src/dfm-burn/dfm-burn-lib/CMakeLists.txt
+++ b/src/dfm-burn/dfm-burn-lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.7)
 
 set (VERSION "1.0.0" CACHE STRING "define project version")
 set(BASE_NAME dfm-burn)

--- a/src/dfm-io/dfm-io/CMakeLists.txt
+++ b/src/dfm-io/dfm-io/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.7)
 
 set (VERSION "1.0.0" CACHE STRING "define project version")
 set(BASE_NAME dfm-io)

--- a/src/dfm-mount/CMakeLists.txt
+++ b/src/dfm-mount/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.7)
 
 set(BASE_NAME dfm-mount)
 

--- a/src/dfm-search/dfm-search-client/CMakeLists.txt
+++ b/src/dfm-search/dfm-search-client/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.7)
 
 project(dfm${DFM_VERSION_MAJOR}-search-client)
 
@@ -18,7 +18,7 @@ target_link_libraries(
     ${PROJECT_NAME}
     Qt${QT_VERSION_MAJOR}::Core
     dfm${DFM_VERSION_MAJOR}-search
-) 
+)
 
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})

--- a/src/dfm-search/dfm-search-lib/CMakeLists.txt
+++ b/src/dfm-search/dfm-search-lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.7)
 
 set (VERSION "1.0.0" CACHE STRING "define project version")
 set(BASE_NAME dfm-search)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.7)
 
 project(util-dfm-tests)
 

--- a/tests/dfm-burn/CMakeLists.txt
+++ b/tests/dfm-burn/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.7)
 
 project(dfm-burn-unitest)
 

--- a/tests/dfm-io/CMakeLists.txt
+++ b/tests/dfm-io/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.7)
 
 project(dfm-io-unitest)
 


### PR DESCRIPTION
Cannot build on archlinux because cmake has dropped compatibility below
3.5.

Log:
