### PR TITLE
fix: enable wildcard pattern matching in FileNameRealTimeStrategy

### DIFF
--- a/src/dfm-search/dfm-search-lib/filenamesearch/filenamestrategies/realtimestrategy.cpp
+++ b/src/dfm-search/dfm-search-lib/filenamesearch/filenamestrategies/realtimestrategy.cpp
@@ -222,7 +222,7 @@ bool FileNameRealTimeStrategy::matchBoolean(const QString &fileName, const Searc
 bool FileNameRealTimeStrategy::matchWildcard(const QString &fileName, const QString &pattern, bool caseSensitive)
 {
     // 利用Qt内置的通配符匹配功能
-    QRegExp regex = QRegExp(pattern, caseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive);
+    QRegExp regex = QRegExp(pattern, caseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive, QRegExp::Wildcard);
     return regex.exactMatch(fileName);
 }
 


### PR DESCRIPTION
Add QRegExp::Wildcard flag to QRegExp constructor in matchWildcard method to properly enable wildcard pattern matching functionality for filename search operations.

Log: enable wildcard pattern matching in FileNameRealTimeStrategy
Bug: https://pms.uniontech.com/bug-view-326059.html