### PR TITLE
feat: add authentication error handling for network unmount

### DIFF
--- a/include/dfm-mount/dfm-mount/base/dmount_global.h
+++ b/include/dfm-mount/dfm-mount/base/dmount_global.h
@@ -337,6 +337,7 @@ enum class DeviceError : int16_t {
     kUserErrorNotMounted,
     kUserErrorNotPoweroffable,
     kUserErrorFailed,
+    kUserErrorAuthenticationFailed
 
 };
 Q_ENUM_NS(DeviceError)

--- a/src/dfm-mount/private/dnetworkmounter.h
+++ b/src/dfm-mount/private/dnetworkmounter.h
@@ -25,6 +25,7 @@ public:
     static void mountNetworkDev(const QString &, GetMountPassInfo, GetUserChoice, DeviceOperateCallbackWithMessage, int);
     static bool unmountNetworkDev(const QString &);
     static void unmountNetworkDevAsync(const QString &, DeviceOperateCallback);
+    static bool unmountNetworkDevAsyncDetailed(const QString &mpt, int *errCode, QString *errMsg);
 
 private:
     static QList<QVariantMap> loginPasswd(const QString &address);


### PR DESCRIPTION
1. Added new DeviceError enum value kUserErrorAuthenticationFailed to handle authentication failures
2. Enhanced unmountNetworkDevAsync to return detailed error information including errno and message from daemon
3. Implemented new method unmountNetworkDevAsyncDetailed that provides granular error reporting through QDBus call
4. Special handling for authentication errors (errno -8) to return appropriate error type
5. This allows better error differentiation and user feedback when unmounting network devices fails due to authentication issues

feat: 添加网络卸载时的认证错误处理

1. 添加新的 DeviceError 枚举值 kUserErrorAuthenticationFailed 用于处理认 证失败情况
2. 增强 unmountNetworkDevAsync 方法以返回包含守护进程错误号和消息的详细 错误信息
3. 实现新方法 unmountNetworkDevAsyncDetailed，通过 QDBus 调用提供详细的 错误报告
4. 对认证错误(errno -8)进行特殊处理以返回适当的错误类型
5. 这些改进使得在网络设备卸载因认证问题失败时能够更好地区分错误并提供用 户反馈