### PR TITLE
fix: update changelog for version 1.3.35

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+util-dfm (1.3.35) unstable; urgency=medium
+
+  * fix bug
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 08 Aug 2025 15:29:22 +0800
+
 util-dfm (1.3.34) unstable; urgency=medium
 
   * fix double free


### PR DESCRIPTION
1. Added new changelog entry for version 1.3.35
2. Documented the bug fix with minimal details
3. Included proper maintainer information and timestamp
4. Following Debian packaging standards for version updates

fix: 更新1.3.35版本的变更日志

1. 为1.3.35版本添加新的变更日志条目
2. 以最少信息记录了错误修复
3. 包含正确的维护者信息和时间戳
4. 遵循Debian打包标准进行版本更新