### PR TITLE
fix: prevent statx usage for non-local files

### DIFF
--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -217,8 +217,7 @@ void DFileInfoPrivate::setErrorFromGError(GError *gerror)
     if (!gerror)
         return;
 
-    if (g_error_matches(gerror, G_IO_ERROR,G_IO_ERROR_FAILED) &&
-            QString(gerror->message).contains(strerror(EHOSTDOWN))) {
+    if (g_error_matches(gerror, G_IO_ERROR, G_IO_ERROR_FAILED) && QString(gerror->message).contains(strerror(EHOSTDOWN))) {
         error.setCode(DFMIOErrorCode::DFM_IO_ERROR_HOST_IS_DOWN);
         error.setMessage(gerror->message);
         return;
@@ -301,12 +300,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_btime.tv_sec > 0
-                        ? quint64(statxBuffer.stx_btime.tv_sec)
-                        : quint64(statxBuffer.stx_ctime.tv_sec);
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_btime.tv_sec > 0
+                    ? quint64(statxBuffer.stx_btime.tv_sec)
+                    : quint64(statxBuffer.stx_ctime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -319,12 +321,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_btime.tv_nsec > 0
-                        ? statxBuffer.stx_btime.tv_nsec / 1000000
-                        : statxBuffer.stx_ctime.tv_nsec / 1000000;
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_btime.tv_nsec > 0
+                    ? statxBuffer.stx_btime.tv_nsec / 1000000
+                    : statxBuffer.stx_ctime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }
@@ -337,12 +342,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_mtime.tv_sec > 0
-                        ? quint64(statxBuffer.stx_mtime.tv_sec)
-                        : quint64(statxBuffer.stx_ctime.tv_sec);
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_mtime.tv_sec > 0
+                    ? quint64(statxBuffer.stx_mtime.tv_sec)
+                    : quint64(statxBuffer.stx_ctime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -355,12 +363,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_mtime.tv_nsec > 0
-                        ? statxBuffer.stx_mtime.tv_nsec / 1000000
-                        : statxBuffer.stx_ctime.tv_nsec / 1000000;
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_mtime.tv_nsec > 0
+                    ? statxBuffer.stx_mtime.tv_nsec / 1000000
+                    : statxBuffer.stx_ctime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }
@@ -373,12 +384,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_atime.tv_sec > 0
-                        ? quint64(statxBuffer.stx_atime.tv_sec)
-                        : quint64(statxBuffer.stx_ctime.tv_sec);
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_atime.tv_sec > 0
+                    ? quint64(statxBuffer.stx_atime.tv_sec)
+                    : quint64(statxBuffer.stx_ctime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -391,12 +405,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_atime.tv_nsec > 0
-                        ? statxBuffer.stx_atime.tv_nsec / 1000000
-                        : statxBuffer.stx_ctime.tv_nsec / 1000000;
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_atime.tv_nsec > 0
+                    ? statxBuffer.stx_atime.tv_nsec / 1000000
+                    : statxBuffer.stx_ctime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }


### PR DESCRIPTION
1. Added check for url.isLocalFile() before using statx() to avoid invalid file operations on remote files
2. Restructured error handling to return QVariant() early for non-local or invalid cases
3. Simplified the statx success check logic and made it consistent across all attribute methods
4. The changes prevent potential invalid data returns when dealing with remote files since statx is only meant for local filesystem operations

Bug: https://pms.uniontech.com/bug-view-330085.html

fix: 修复非本地文件使用statx导致的异常数据问题

1. 在使用statx()前增加url.isLocalFile()检查，避免对远程文件进行无效操作
2. 重构错误处理逻辑，对非本地或无效情况提前返回QVariant()
3. 简化statx成功检查逻辑，确保所有属性方法处理一致
4. 防止处理远程文件时返回无效数据，因为statx仅适用于本地文件系统操作