### PR TITLE
fix: prevent statx usage for non-local files

### DIFF
--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -300,12 +300,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_btime.tv_sec > 0
-                        ? quint64(statxBuffer.stx_btime.tv_sec)
-                        : quint64(statxBuffer.stx_ctime.tv_sec);
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_btime.tv_sec > 0
+                    ? quint64(statxBuffer.stx_btime.tv_sec)
+                    : quint64(statxBuffer.stx_ctime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -318,12 +321,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_btime.tv_nsec > 0
-                        ? statxBuffer.stx_btime.tv_nsec / 1000000
-                        : statxBuffer.stx_ctime.tv_nsec / 1000000;
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_btime.tv_nsec > 0
+                    ? statxBuffer.stx_btime.tv_nsec / 1000000
+                    : statxBuffer.stx_ctime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }
@@ -336,12 +342,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_mtime.tv_sec > 0
-                        ? quint64(statxBuffer.stx_mtime.tv_sec)
-                        : quint64(statxBuffer.stx_ctime.tv_sec);
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_mtime.tv_sec > 0
+                    ? quint64(statxBuffer.stx_mtime.tv_sec)
+                    : quint64(statxBuffer.stx_ctime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -354,12 +363,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_mtime.tv_nsec > 0
-                        ? statxBuffer.stx_mtime.tv_nsec / 1000000
-                        : statxBuffer.stx_ctime.tv_nsec / 1000000;
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_mtime.tv_nsec > 0
+                    ? statxBuffer.stx_mtime.tv_nsec / 1000000
+                    : statxBuffer.stx_ctime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }
@@ -372,12 +384,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_atime.tv_sec > 0
-                        ? quint64(statxBuffer.stx_atime.tv_sec)
-                        : quint64(statxBuffer.stx_ctime.tv_sec);
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_atime.tv_sec > 0
+                    ? quint64(statxBuffer.stx_atime.tv_sec)
+                    : quint64(statxBuffer.stx_ctime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -390,12 +405,15 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             struct statx statxBuffer;
             unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
             const QUrl &url = q->uri();
+            if (!url.isLocalFile())
+                return QVariant();
             int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret == 0) {
-                return statxBuffer.stx_atime.tv_nsec > 0
-                        ? statxBuffer.stx_atime.tv_nsec / 1000000
-                        : statxBuffer.stx_ctime.tv_nsec / 1000000;
-            }
+            if (ret != 0)
+                return QVariant();
+
+            return statxBuffer.stx_atime.tv_nsec > 0
+                    ? statxBuffer.stx_atime.tv_nsec / 1000000
+                    : statxBuffer.stx_ctime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }


### PR DESCRIPTION
1. Added check for url.isLocalFile() before using statx() to avoid invalid file operations on remote files
2. Restructured error handling to return QVariant() early for non-local or invalid cases
3. Simplified the statx success check logic and made it consistent across all attribute methods
4. The changes prevent potential invalid data returns when dealing with remote files since statx is only meant for local filesystem operations

Log: prevent statx usage for non-local files
Bug: https://pms.uniontech.com/bug-view-330085.html