### PR TITLE
feat(denumerator): add initEnumerator demo and improve error handling

### DIFF
--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -236,7 +236,11 @@ bool DEnumeratorPrivate::checkFilter()
 bool DEnumeratorPrivate::openDirByfts()
 {
     char *paths[2] = { nullptr, nullptr };
-    paths[0] = strdup(filePath(uri));
+    paths[0] = filePath(uri);
+    if (!paths[0]) {
+        error.setCode(DFMIOErrorCode::DFM_IO_ERROR_FAILED);
+        return false;
+    }
     int (*compare)(const FTSENT **, const FTSENT **);
     compare = nullptr;
     if (sortRoleFlag == DEnumerator::SortRoleCompareFlag::kSortRoleCompareFileName) {
@@ -367,12 +371,12 @@ void DEnumeratorPrivate::setQueryAttributes(const QString &attributes)
 char *DEnumeratorPrivate::filePath(const QUrl &url)
 {
     if (url.userInfo().startsWith("originPath::"))
-        return url.userInfo().replace("originPath::", "").toLatin1().data();
+        return strdup(url.userInfo().replace("originPath::", "").toLatin1().constData());
 
     QString path = url.path();
     if (path != "/" && path.endsWith("/"))
         path = path.left(path.length() - 1);
-    return path.toUtf8().data();
+    return strdup(path.toUtf8().constData());
 }
 
 QUrl DEnumeratorPrivate::buildUrl(const QUrl &url, const char *fileName)
@@ -743,7 +747,11 @@ QList<QSharedPointer<DEnumerator::SortFileInfo>> DEnumerator::sortFileInfoList()
     QSet<QString> hideList;
     QUrl urlHidden = d->buildUrl(d->uri, ".hidden");
     hideList = DLocalHelper::hideListFromUrl(urlHidden);
-    const char *dirPath = d->filePath(d->uri);
+    char *dirPath = d->filePath(d->uri);
+    if (!dirPath) {
+        qWarning() << "Failed to get file path for uri:" << d->uri;
+        return {};
+    }
     while (1) {
         FTSENT *ent = fts_read(d->fts);
 
@@ -764,6 +772,9 @@ QList<QSharedPointer<DEnumerator::SortFileInfo>> DEnumerator::sortFileInfoList()
 
     fts_close(d->fts);
     d->fts = nullptr;
+
+    // Clean up allocated memory
+    free(dirPath);
 
     if (d->isMixDirAndFile)
         return listFile;

--- a/src/dfm-io/tools/dfm-list.cpp
+++ b/src/dfm-io/tools/dfm-list.cpp
@@ -5,6 +5,7 @@
 #include <dfm-io/dfmio_global.h>
 #include <dfm-io/denumerator.h>
 #include <dfm-io/denumeratorfuture.h>
+#include <dfm-io/dfileinfo.h>
 
 #include <stdio.h>
 
@@ -62,9 +63,93 @@ static void enum_uri_async_test(const QUrl &url)
     future->startAsyncIterator();
 }
 
+static void initEnumerator_demo(const QUrl &url)
+{
+    qInfo() << "--- initEnumerator Demo ---";
+
+    QSharedPointer<DEnumerator> enumerator { new DEnumerator(url) };
+    if (!enumerator) {
+        err_msg("create enumerator failed.");
+        return;
+    }
+
+    // Demo 1: oneByone = true (GIO mode)
+    qInfo() << "Demo 1: oneByone = true (GIO mode)";
+    bool result1 = enumerator->initEnumerator(true);
+    qInfo() << "initEnumerator(true) result:" << result1;
+    if (result1) {
+        int count = 0;
+        while (enumerator->hasNext()) {
+            const QUrl &nextUrl = enumerator->next();
+            QSharedPointer<DFileInfo> fileInfo = enumerator->fileInfo();
+            if (fileInfo) {
+                QString fileName = fileInfo->attribute(DFileInfo::AttributeID::kStandardName).toString();
+                bool isDir = fileInfo->attribute(DFileInfo::AttributeID::kStandardIsDir).toBool();
+                qint64 size = fileInfo->attribute(DFileInfo::AttributeID::kStandardSize).toLongLong();
+                qInfo() << "File:" << fileName << "Dir:" << isDir << "Size:" << size;
+            }
+            ++count;
+        }
+        qInfo() << "GIO mode count:" << count;
+    } else {
+        DFMIOError error = enumerator->lastError();
+        qInfo() << "GIO mode failed:" << error.errorMsg();
+    }
+
+    // Demo 2: oneByone = false (FTS mode)
+    qInfo() << "Demo 2: oneByone = false (FTS mode)";
+    QSharedPointer<DEnumerator> enumerator2 { new DEnumerator(url) };
+    if (enumerator2) {
+        bool result2 = enumerator2->initEnumerator(false);
+        qInfo() << "initEnumerator(false) result:" << result2;
+        if (result2) {
+            // Use sortFileInfoList for FTS mode
+            QList<QSharedPointer<DEnumerator::SortFileInfo>> sortList = enumerator2->sortFileInfoList();
+            qInfo() << "FTS mode count:" << sortList.size();
+            for (const auto &sortInfo : sortList) {
+                QString fileName = sortInfo->url.fileName();
+                qInfo() << "File:" << fileName << "Dir:" << sortInfo->isDir << "Size:" << sortInfo->filesize;
+            }
+        } else {
+            DFMIOError error = enumerator2->lastError();
+            qInfo() << "FTS mode failed:" << error.errorMsg();
+        }
+    }
+
+    // Demo 3: With filters
+    qInfo() << "Demo 3: With filters";
+    QSharedPointer<DEnumerator> enumerator3 { new DEnumerator(url, QStringList(),
+                                                             DEnumerator::DirFilters(DEnumerator::DirFilter::kFiles),
+                                                             DEnumerator::IteratorFlags()) };
+    if (enumerator3) {
+        bool result3 = enumerator3->initEnumerator(true);
+        qInfo() << "initEnumerator with filters result:" << result3;
+        if (result3) {
+            int count = 0;
+            while (enumerator3->hasNext()) {
+                const QUrl &nextUrl = enumerator3->next();
+                QSharedPointer<DFileInfo> fileInfo = enumerator3->fileInfo();
+                if (fileInfo) {
+                    QString fileName = fileInfo->attribute(DFileInfo::AttributeID::kStandardName).toString();
+                    bool isFile = fileInfo->attribute(DFileInfo::AttributeID::kStandardIsFile).toBool();
+                    qInfo() << "File only:" << fileName << "IsFile:" << isFile;
+                }
+                ++count;
+            }
+            qInfo() << "Filtered files count:" << count;
+        } else {
+            DFMIOError error = enumerator3->lastError();
+            qInfo() << "Filtered mode failed:" << error.errorMsg();
+        }
+    }
+
+    qInfo() << "--- initEnumerator Demo End ---";
+}
+
 void usage()
 {
     err_msg("usage: dfm-list [-l] uri.");
+    err_msg("usage: dfm-list [-d] uri.  # run initEnumerator demo");
 }
 
 // list all children in a directory.
@@ -78,12 +163,20 @@ int main(int argc, char *argv[])
     QCoreApplication a(argc, argv);
 
     char *uri = nullptr;
+    bool demoMode = false;
+
     if (argc == 3) {
         if (strcmp(argv[1], "-l") == 0) {
             lflag = true;
             uri = argv[2];
         } else if (strcmp(argv[2], "-l") == 0) {
             lflag = true;
+            uri = argv[1];
+        } else if (strcmp(argv[1], "-d") == 0) {
+            demoMode = true;
+            uri = argv[2];
+        } else if (strcmp(argv[2], "-d") == 0) {
+            demoMode = true;
             uri = argv[1];
         } else {
             usage();
@@ -99,9 +192,13 @@ int main(int argc, char *argv[])
     if (!url.isValid())
         return 1;
 
-    enum_uri(url);
-
-    enum_uri_async_test(url);
+    if (demoMode) {
+        initEnumerator_demo(url);
+        return 0;
+    } else {
+        enum_uri(url);
+        enum_uri_async_test(url);
+    }
 
     return a.exec();
 }


### PR DESCRIPTION
- Add initEnumerator demo mode to showcase different enumeration methods
- Implement better error handling and logging in DEnumerator
- Fix potential memory leaks in filePath and sortFileInfoList functions
- Update dfm-list tool to include demo mode for testing new features

Log: feat(denumerator): add initEnumerator demo and improve error handling
Bug: https://pms.uniontech.com/bug-view-333909.html