### PR TITLE
fix: correct file name comparison logic

### DIFF
--- a/include/dfm-io/dfm-io/dfmio_utils.h
+++ b/include/dfm-io/dfm-io/dfmio_utils.h
@@ -59,6 +59,9 @@ public:
     static qint64 deviceBytesFree(const QUrl &url);
     static bool supportTrash(const QUrl &url);
     static bool isGvfsFile(const QUrl &url);
+    
+    // String comparison function for file names
+    static bool compareFileName(const QString &str1, const QString &str2);
 
 private:
     static QMap<QString, QString>

--- a/src/dfm-io/dfm-io/dfmio_utils.cpp
+++ b/src/dfm-io/dfm-io/dfmio_utils.cpp
@@ -62,7 +62,7 @@ QString DFMUtils::deviceNameFromUrl(const QUrl &url)
     if (!url.isValid())
         return QString();
 
-    g_autoptr(GFile) gfile = g_file_new_for_uri(url.toString().toStdString().c_str());
+    g_autoptr(GFile) gfile = g_file_new_for_uri(url.toString().toLocal8Bit().data());
     g_autoptr(GUnixMountEntry) mount = g_unix_mount_for(g_file_peek_path(gfile), nullptr);
     if (mount)
         return QString::fromLocal8Bit(g_unix_mount_get_device_path(mount));
@@ -376,4 +376,9 @@ QMap<QString, QString> DFMUtils::fstabBindInfo()
     }
 
     return table;
+}
+
+bool DFMUtils::compareFileName(const QString &str1, const QString &str2)
+{
+    return DLocalHelper::compareByStringEx(str1, str2);
 }

--- a/src/dfm-io/dfm-io/utils/dlocalhelper.cpp
+++ b/src/dfm-io/dfm-io/utils/dlocalhelper.cpp
@@ -994,35 +994,7 @@ bool DLocalHelper::compareByStringEx(const QString &str1, const QString &str2)
         return 0;
     };
 
-    // --- 主流程 ---
-    QString name1, suf1;
-    int dotPos1 = str1.lastIndexOf('.');
-    if (dotPos1 <= 0) {
-        name1 = str1;
-    } else {
-        name1 = str1.left(dotPos1);
-        suf1 = str1.mid(dotPos1 + 1);
-    }
-
-    QString name2, suf2;
-    int dotPos2 = str2.lastIndexOf('.');
-    if (dotPos2 <= 0) {
-        name2 = str2;
-    } else {
-        name2 = str2.left(dotPos2);
-        suf2 = str2.mid(dotPos2 + 1);
-    }
-
-    int nameCompareResult = compareUnified(name1, name2);
-    if (nameCompareResult != 0) {
-        return nameCompareResult < 0;
-    }
-
-    // 如果文件名相同，但一个有后缀一个没有，没有后缀的排前面
-    if (suf1.isEmpty() && !suf2.isEmpty()) return true;
-    if (!suf1.isEmpty() && suf2.isEmpty()) return false;
-
-    return compareUnified(suf1, suf2) < 0;
+    return compareUnified(str1, str2) < 0;
 }
 
 bool DLocalHelper::compareByString(const QString &str1, const QString &str2)


### PR DESCRIPTION
1. Removed the previous file extension splitting logic in DLocalHelper::compareByStringEx that caused incorrect sorting
2. Added a new public method DFMUtils::compareFileName to expose the corrected comparison function
3. Now comparing full strings without separating names and extensions
4. Also fixed URL handling to use toLocal8Bit() instead of toStdString() for better compatibility

The change was necessary because:
1. The old implementation incorrectly sorted files by splitting names and extensions
2. The new approach provides more accurate natural sorting by comparing entire strings
3. Makes the functionality available as a public API for broader use
4. Improves compatibility with various file name encodings

Bug: https://pms.uniontech.com/bug-view-335751.html

fix: 修正文件名比较逻辑

1. 移除 DLocalHelper::compareByStringEx 中导致排序错误的扩展名分割逻辑
2. 新增公共方法 DFMUtils::compareFileName 提供正确的比较功能
3. 现在直接比较完整字符串而不分割名称和扩展名
4. 同时将 URL 处理改为使用 toLocal8Bit() 提高兼容性

修改原因：
1. 旧实现在分割文件名和扩展名时排序不正确
2. 新方法通过比较完整字符串提供更准确的自然排序
3. 将该功能作为公共 API 开放以方便其他模块使用
4. 提高对各种文件名编码的兼容性