### PR TITLE
fix: filter hidden files in lucene query to prevent result loss

### DIFF
--- a/src/dfm-search/dfm-search-lib/filenamesearch/filenamestrategies/indexedstrategy.cpp
+++ b/src/dfm-search/dfm-search-lib/filenamesearch/filenamestrategies/indexedstrategy.cpp
@@ -726,6 +726,15 @@ Lucene::QueryPtr FileNameIndexedStrategy::buildLuceneQuery(const IndexQuery &que
         }
     }
 
+    // Filter hidden files at query level to avoid losing results due to maxResults limit
+    if (hasValidQuery && Q_LIKELY(!m_options.includeHidden())) {
+        QueryPtr hiddenQuery = Lucene::newLucene<Lucene::TermQuery>(
+                Lucene::newLucene<Lucene::Term>(
+                        Lucene::StringUtils::toUnicode("is_hidden"),
+                        Lucene::StringUtils::toUnicode("Y")));
+        finalQuery->add(hiddenQuery, Lucene::BooleanClause::MUST_NOT);
+    }
+
     return hasValidQuery ? finalQuery : nullptr;
 }
 


### PR DESCRIPTION
Added hidden file filtering at the query level in the Lucene search
implementation. Previously, hidden files were being filtered after the
search results were returned, which could cause valid non-hidden files
to be excluded when the result set exceeded the maxResults limit. By
adding the hidden file filter directly to the Lucene query using a
MUST_NOT clause, we ensure that hidden files are excluded before result
limiting occurs, preventing the loss of legitimate search results.

Influence:
1. Test file searches with hidden files present in the directory
2. Verify that hidden files are properly excluded from search results
3. Test searches with large numbers of files to ensure maxResults limit
works correctly
4. Confirm that non-hidden files are not lost when hidden files are
present
5. Validate search performance with the new query-level filtering

fix: 在 Lucene 查询中过滤隐藏文件以防止结果丢失

在 Lucene 搜索实现中添加了查询级别的隐藏文件过滤。之前隐藏文件是在搜索结
果返回后才被过滤的，这可能导致当结果集超过 maxResults 限制时，有效的非隐
藏文件被排除。通过在 Lucene 查询中直接使用 MUST_NOT 子句添加隐藏文件过滤
器，我们确保隐藏文件在结果限制发生之前就被排除，防止合法搜索结果的丢失。

Influence:
1. 测试目录中存在隐藏文件时的文件搜索
2. 验证隐藏文件是否被正确排除在搜索结果之外
3. 测试包含大量文件的搜索，确保 maxResults 限制正常工作
4. 确认当存在隐藏文件时，非隐藏文件不会丢失
5. 验证新的查询级过滤对搜索性能的影响
