### PR TITLE
Fix[denumerator]: close GFileEnumerator when enumeration finishes

### DIFF
--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -644,12 +644,6 @@ bool DEnumerator::hasNext() const
 
         g_object_unref(nextInfo);
 
-        if (gerror) {
-            d->setErrorFromGError(gerror);
-            g_error_free(gerror);
-            gerror = nullptr;
-        }
-
         if (!d->checkFilter())
             return this->hasNext();
 
@@ -659,7 +653,18 @@ bool DEnumerator::hasNext() const
     // nextInfo == NULL: either finished or an error occurred
     if (gerror) {
         d->setErrorFromGError(gerror);
+        d->nextUrl = QUrl();
+        d->dfileInfoNext.reset();
         return true;
+    }
+
+    // 枚举完成，关闭并释放当前枚举器，释放 fd
+    if (!d->stackEnumerator.isEmpty()) {
+        GFileEnumerator *enumerator = d->stackEnumerator.pop();
+        if (enumerator) {
+            g_file_enumerator_close(enumerator, nullptr, nullptr);
+            g_object_unref(enumerator);
+        }
     }
 
     return false;

--- a/src/dfm-io/dfm-io/private/denumerator_p.h
+++ b/src/dfm-io/dfm-io/private/denumerator_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2020 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
Close and release GFileEnumerator after all entries are consumed to prevent file descriptor leak on GVFS mount points (e.g. Vault).

枚举完成后关闭并释放GFileEnumerator，防止GVFS挂载点（如保险箱）的文件描述符泄漏。

Log: 修复枚举器耗尽后fd未释放的问题
Influence: 修复遍历Vault等GVFS目录后文件描述符一直被占用的问题，枚举完成后正确释放资源。