### PR TITLE
build: update debian package configuration for search component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ debian/libdfm-mount/*
 debian/libdfm-mount-dev/*
 debian/libdfm-burn/*
 debian/libdfm-burn-dev/*
+debian/libdfm-search-dev/*
+debian/libdfm-search/*
 debian/*.log
 debian/*.substvars
 debian/files

--- a/debian/libdfm-search.install
+++ b/debian/libdfm-search.install
@@ -1,2 +1,2 @@
-usr/lib/*/libdfm-search*.so* 
-usr/libexec/dfm-search-client
+usr/lib/*/libdfm-search*.so*
+usr/bin/dfm-searcher


### PR DESCRIPTION
  Added libdfm-search and libdfm-search-dev directories to .gitignore
  Updated libdfm-search.install to replace dfm-search-client with dfm-searcher
  Changed binary installation path from /usr/libexec to /usr/bin
  Fixed missing newline at end of install file

  This change aligns the package configuration with the current binary naming
  and location conventions. The search client binary has been renamed and
  relocated to the standard /usr/bin directory.

  The change maintains package installation correctness while updating paths
  to match current build output

  Influence:
  1. Verify debian package builds without errors
  2. Check that dfm-searcher binary is correctly installed to /usr/bin
  3. Ensure .gitignore properly excludes generated debian directories
  4. Confirm package dependencies are still satisfied

  build: 更新搜索组件的 debian 打包配置

  在 .gitignore 中添加了 libdfm-search 和 libdfm-search-dev 目录
  更新 libdfm-search.install，将 dfm-search-client 替换为 dfm-searcher
  将二进制文件安装路径从 /usr/libexec 更改为 /usr/bin
  修复了安装文件末尾缺少换行符的问题

  此变更使打包配置与当前二进制命名和位置约定保持一致
  搜索客户端二进制文件已重命名并重新定位到标准的 /usr/bin 目录

  该变更在保持打包正确性的同时更新路径以匹配当前构建输出

  Influence:
  1. 验证 debian 包构建无错误
  2. 检查 dfm-searcher 二进制文件是否正确安装到 /usr/bin
  3. 确保 .gitignore 正确排除生成的 debian 目录
  4. 确认包依赖关系仍然满足