### PR TITLE
refactor: centralize PROJECT_VERSION_MAJOR configuration in root CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ if(OPT_ENABLE_QT6)
         set(DFM_BUILD_WITH_QT6 TRUE)
         set(QT_VERSION_MAJOR 6)
         set(DFM_VERSION_MAJOR 6)
+        set(PROJECT_VERSION_MAJOR 1)
     endif()
 endif()
 
@@ -28,6 +29,7 @@ if(NOT DFM_BUILD_WITH_QT6)
    message(WARNING "Qt6 not found, Use Qt5.")
    set(QT_VERSION_MAJOR 5)
    set(DFM_VERSION_MAJOR "")
+   set(PROJECT_VERSION_MAJOR 0)
 endif()
 
 # default

--- a/src/dfm-burn/dfm-burn-lib/dfm-burn.cmake
+++ b/src/dfm-burn/dfm-burn-lib/dfm-burn.cmake
@@ -26,10 +26,6 @@ if (NOT VERSION)
     set(VERSION "1.0.0")
 endif()
 
-if (NOT PROJECT_VERSION_MAJOR)
-    set(PROJECT_VERSION_MAJOR 1)
-endif()
-
 set_target_properties(
     ${BIN_NAME} PROPERTIES
     VERSION ${VERSION}

--- a/src/dfm-io/dfm-io/dfm-io.cmake
+++ b/src/dfm-io/dfm-io/dfm-io.cmake
@@ -30,10 +30,6 @@ if (NOT VERSION)
     set(VERSION "1.0.0")
 endif()
 
-if (NOT PROJECT_VERSION_MAJOR)
-    set(PROJECT_VERSION_MAJOR 1)
-endif()
-
 set_target_properties(
     ${BIN_NAME} PROPERTIES
     VERSION ${VERSION}

--- a/src/dfm-mount/dfm-mount.cmake
+++ b/src/dfm-mount/dfm-mount.cmake
@@ -21,10 +21,6 @@ if (NOT VERSION)
     set(VERSION "1.0.0")
 endif()
 
-if (NOT PROJECT_VERSION_MAJOR)
-    set(PROJECT_VERSION_MAJOR 1)
-endif()
-
 set_target_properties(
     ${BIN_NAME} PROPERTIES
     VERSION ${VERSION}


### PR DESCRIPTION
Moved PROJECT_VERSION_MAJOR definition from submodule cmake files to root CMakeLists.txt for unified version management
Qt6 build sets PROJECT_VERSION_MAJOR to 1 (libdfm-*.so.1) Qt5 build sets PROJECT_VERSION_MAJOR to 0 (libdfm-*.so.0) Removed redundant PROJECT_VERSION_MAJOR settings from:
  - src/dfm-burn/dfm-burn-lib/dfm-burn.cmake
  - src/dfm-io/dfm-io/dfm-io.cmake
  - src/dfm-mount/dfm-mount.cmake

This change ensures consistent SOVERSION across all submodules and simplifies version management by having a single source of truth

The change maintains binary compatibility while improving build configuration clarity

Influence:
1. Verify libdfm-burn.so.* has correct SOVERSION after build
2. Verify libdfm-io.so.* has correct SOVERSION after build
3. Verify libdfm-mount.so.* has correct SOVERSION after build
4. Check Qt5 build produces libdfm-*.so.0
5. Check Qt6 build produces libdfm-*.so.1

refactor: 将 PROJECT_VERSION_MAJOR 配置集中到根 CMakeLists 中

将 PROJECT_VERSION_MAJOR 定义从子模块 cmake 文件移到根 CMakeLists.txt 实现统一的版本管理
Qt6 构建设置 PROJECT_VERSION_MAJOR 为 1 (libdfm-*.so.1) Qt5 构建设置 PROJECT_VERSION_MAJOR 为 0 (libdfm-*.so.0) 移除了以下文件中的冗余 PROJECT_VERSION_MAJOR 设置：
  - src/dfm-burn/dfm-burn-lib/dfm-burn.cmake
  - src/dfm-io/dfm-io/dfm-io.cmake
  - src/dfm-mount/dfm-mount.cmake

此变更确保所有子模块的 SOVERSION 一致，并通过单一配置源简化版本管理

该变更保持二进制兼容性的同时提高了构建配置的清晰度

Influence:
1. 验证构建后 libdfm-burn.so.* 具有正确的 SOVERSION
2. 验证构建后 libdfm-io.so.* 具有正确的 SOVERSION
3. 验证构建后 libdfm-mount.so.* 具有正确的 SOVERSION
4. 检查 Qt5 构建产生 libdfm-*.so.0
5. 检查 Qt6 构建产生 libdfm-*.so.1