### PR TITLE
build: add diagnostic logging to debian/rules for package debugging

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -32,5 +32,35 @@ $(shell sed -e 's/@QT_SUFFIX@/$(QT_SUFFIX)/g' \
 	dh $@ --parallel
 
 override_dh_auto_configure:
+	@echo "======= [debian/rules] 打包诊断信息 ======="
+	@echo "  MAJOR_VERSION  = $(MAJOR_VERSION)"
+	@echo "  USE_QT6        = $(USE_QT6)"
+	@echo "  QT_SUFFIX      = $(QT_SUFFIX)"
+	@echo "  QT_SELECT      = $$QT_SELECT"
+	@echo "  DEB_HOST_MULTIARCH = $(DEB_HOST_MULTIARCH)"
+	@echo ""
+	@echo "--- control 中的包名 (QT_SUFFIX=$(QT_SUFFIX)) ---"
+	@grep "^Package:" debian/control | sed 's/^/  /'
+	@echo ""
+	@echo "--- 匹配到的 .install 文件 ---"
+	@for f in debian/libdfm*$(QT_SUFFIX)*.install; do \
+		[ -f "$$f" ] && echo "  [匹配] $$f" || true; \
+	done
+	@for f in debian/libdfm*.install; do \
+		case "$$f" in \
+			*$(QT_SUFFIX)*) ;; \
+			*) echo "  [残留] $$f (QT_SUFFIX=$(QT_SUFFIX) 时不会被 dh_install 使用)";; \
+		esac; \
+	done
+	@echo ""
+	@echo "--- 构建产物 (debian/tmp 中的库文件) ---"
+	@find debian/tmp/usr/lib -name 'libdfm*.so*' 2>/dev/null | sed 's/^/  /' || echo "  (debian/tmp 尚未生成，将在 build 阶段出现)"
+	@echo ""
+	@echo "--- 构建产物 (debian/tmp 中的头文件目录) ---"
+	@find debian/tmp/usr/include -maxdepth 1 -type d 2>/dev/null | sed 's|debian/tmp/usr/include/|  /usr/include/|' || echo "  (debian/tmp 尚未生成)"
+	@echo ""
+	@echo "--- 构建产物 (debian/tmp 中的 pkg-config) ---"
+	@find debian/tmp/usr/lib -name 'dfm*.pc' 2>/dev/null | sed 's/^/  /' || echo "  (debian/tmp 尚未生成)"
+	@echo "==========================================="
 	dh_auto_configure -- \
 	  -DHOST_MULTIARCH="$(DEB_HOST_MULTIARCH)"


### PR DESCRIPTION
Added diagnostic output to override_dh_auto_configure in debian/rules Prints version detection results (MAJOR_VERSION, USE_QT6, QT_SUFFIX) Displays control package names and matching .install file status Lists build artifacts in debian/tmp (.so files, headers, pkg-config) Helps diagnose dh_install warnings caused by QT_SUFFIX mismatch Previously libdfm6-io.install referenced libdfm6-io*.so* but build produces libdfm-io.so* without the version suffix, causing warnings

Influence:
1. Build output will now include diagnostic info at configure stage
2. No functional change to package build process
3. Helps identify .install file and build artifact name mismatches
4. Useful for debugging future packaging issues related to QT_SUFFIX

build: 在 debian/rules 中添加打包诊断日志

在 debian/rules 的 override_dh_auto_configure 中添加了诊断输出 打印版本检测结果 (MAJOR_VERSION、USE_QT6、QT_SUFFIX)
显示 control 包名以及匹配的 .install 文件状态
列出 debian/tmp 中的构建产物 (.so 文件、头文件、pkg-config)
帮助诊断由 QT_SUFFIX 不匹配导致的 dh_install 警告
此前 libdfm6-io.install 引用了 libdfm6-io*.so* 但构建产物为
libdfm-io.so*（无版本后缀），导致打包警告

Influence:
1. 构建输出将在 configure 阶段包含诊断信息
2. 不影响包构建过程的功能
3. 有助于识别 .install 文件与构建产物名称不匹配的问题
4. 方便排查未来与 QT_SUFFIX 相关的打包问题