### PR TITLE
build: add Qt6 runtime detection when os-version is unavailable

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,16 @@ MAJOR_VERSION := $(shell if [ -f $(OS_VERSION_FILE) ]; then \
 # 版本判断: MajorVersion > 20 使用 Qt6, 否则使用 Qt5
 USE_QT6 := $(shell if [ "$(MAJOR_VERSION)" -gt 20 ] 2>/dev/null; then echo yes; else echo no; fi)
 
+# MajorVersion 为 99 时（/etc/os-version 不存在），检查 Qt6 是否实际安装
+ifeq ($(MAJOR_VERSION),99)
+HAS_QT6 := $(shell pkg-config --exists Qt6Core 2>/dev/null && echo yes || echo no)
+ifeq ($(HAS_QT6),yes)
+    USE_QT6 := yes
+else
+    USE_QT6 := no
+endif
+endif
+
 # 设置 QT_SELECT 环境变量
 ifeq ($(USE_QT6),yes)
     export QT_SELECT=6
@@ -34,6 +44,7 @@ $(shell sed -e 's/@QT_SUFFIX@/$(QT_SUFFIX)/g' \
 override_dh_auto_configure:
 	@echo "======= [debian/rules] 打包诊断信息 ======="
 	@echo "  MAJOR_VERSION  = $(MAJOR_VERSION)"
+	@echo "  HAS_QT6        = $(HAS_QT6) (pkg-config Qt6Core)"
 	@echo "  USE_QT6        = $(USE_QT6)"
 	@echo "  QT_SUFFIX      = $(QT_SUFFIX)"
 	@echo "  QT_SELECT      = $$QT_SELECT"


### PR DESCRIPTION
When /etc/os-version does not exist MAJOR_VERSION defaults to 99 Previously this always assumed Qt6 was available and set USE_QT6=yes Now uses pkg-config --exists Qt6Core to check actual Qt6 installation Falls back to Qt5 if Qt6Core is not found on the system Also outputs HAS_QT6 status in the diagnostic logging section

Influence:
1. Build will correctly fallback to Qt5 when Qt6 is not installed
2. Prevents build failures on systems without /etc/os-version or Qt6
3. Diagnostic output now shows Qt6 detection result for debugging
4. MAJOR_VERSION >= 21 path remains unchanged

build: 在 os-version 不可用时添加 Qt6 运行时检测

当 /etc/os-version 不存在时 MAJOR_VERSION 默认为 99
此前始终假设 Qt6 可用并设置 USE_QT6=yes
现在使用 pkg-config --exists Qt6Core 检测 Qt6 实际安装情况
如果系统未安装 Qt6Core 则回退到 Qt5
同时在诊断日志中输出 HAS_QT6 检测状态

Influence:
1. 未安装 Qt6 时构建将正确回退到 Qt5
2. 防止在缺少 /etc/os-version 或 Qt6 的系统上构建失败
3. 诊断输出现在显示 Qt6 检测结果便于调试
4. MAJOR_VERSION >= 21 的路径保持不变