### PR TITLE
fix(build): detect Qt6 availability when os-version is missing

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,16 @@ MAJOR_VERSION := $(shell if [ -f $(OS_VERSION_FILE) ]; then \
 # 版本判断: MajorVersion > 20 使用 Qt6, 否则使用 Qt5
 USE_QT6 := $(shell if [ "$(MAJOR_VERSION)" -gt 20 ] 2>/dev/null; then echo yes; else echo no; fi)
 
+# MajorVersion 为 99 时（/etc/os-version 不存在），检查 Qt6 是否实际安装
+ifeq ($(MAJOR_VERSION),99)
+HAS_QT6 := $(shell pkg-config --exists Qt6Core 2>/dev/null && echo yes || echo no)
+ifeq ($(HAS_QT6),yes)
+    USE_QT6 := yes
+else
+    USE_QT6 := no
+endif
+endif
+
 # 设置 QT_SELECT 环境变量
 ifeq ($(USE_QT6),yes)
     export QT_SELECT=6


### PR DESCRIPTION
When /etc/os-version does not exist, MAJOR_VERSION defaults to 99, which incorrectly selects Qt6 due to 99 > 20 being true. Add a pkg-config check for Qt6Core to determine actual Qt6 availability, preventing build failures on systems without Qt6 installed.

当 /etc/os-version 不存在时，MAJOR_VERSION 默认为 99，
由于 99 > 20 为真会错误地选择 Qt6。
新增通过 pkg-config 检测 Qt6Core 是否实际安装的逻辑，
避免在未安装 Qt6 的系统上构建失败。

Influence:
1. 修复了 /etc/os-version 缺失时 Qt 版本选择错误的问题
2. 确保在没有 Qt6 的环境中正确回退到 Qt5 构建