### PR TITLE
refactor: add file size and checksum fields

### DIFF
--- a/include/dfm-search/dfm-search/field_names.h
+++ b/include/dfm-search/dfm-search/field_names.h
@@ -36,6 +36,7 @@ constexpr const wchar_t kIsHidden[] = L"is_hidden";
 constexpr const wchar_t kAncestorPaths[] = L"ancestor_paths";
 constexpr const wchar_t kBirthTime[] = L"birth_time";
 constexpr const wchar_t kModifyTime[] = L"modify_time";
+constexpr const wchar_t kFileSize[] = L"file_size";
 }   // namespace Content
 
 // OCR text index field names
@@ -47,6 +48,8 @@ constexpr const wchar_t kIsHidden[] = L"is_hidden";
 constexpr const wchar_t kAncestorPaths[] = L"ancestor_paths";
 constexpr const wchar_t kBirthTime[] = L"birth_time";
 constexpr const wchar_t kModifyTime[] = L"modify_time";
+constexpr const wchar_t kFileSize[] = L"file_size";
+constexpr const wchar_t kCheckSum[] = L"checksum";
 }   // namespace OcrText
 
 }   // namespace LuceneFieldNames


### PR DESCRIPTION
Added file size field `kFileSize` to both Content and OcrText namespaces
in field_names.h to support file size based searching.
Added checksum field `kCheckSum` specifically to OcrText namespace for
integrity verification of OCR processed files.

These changes enable:
1. File size based searching capability in the search engine
2. Checksum verification for OCR processed documents
3. Better indexing and filtering capabilities

Influence:
1. Test searching with file size conditions
2. Verify OCR document integrity checks with checksum field
3. Ensure backward compatibility with existing search queries

refactor: 添加文件大小和校验和字段

在field_names.h中向Content和OcrText命名空间添加了文件大小字段`kFileSize`
以支持基于文件大小的搜索。
向OcrText命名空间专门添加了校验和字段`kCheckSum`用于OCR处理文件的完整性
验证。

这些改动实现了：
1. 搜索引擎中对文件大小条件的搜索能力
2. 使用校验和验证OCR处理文档的完整性
3. 更好的索引和过滤能力

Influence:
1. 测试带文件大小条件的搜索功能
2. 使用校验和字段验证OCR文档完整性
3. 确保与现有搜索查询的向后兼容性
