### PR TITLE
perf: cache resolved indexed directories to avoid repeated resolution

### DIFF
--- a/src/dfm-search/dfm-search-lib/utils/searchutility.cpp
+++ b/src/dfm-search/dfm-search-lib/utils/searchutility.cpp
@@ -514,7 +514,7 @@ QStringList defaultContentSearchExtensions()
 
 QStringList defaultIndexedDirectory()
 {
-    const QStringList &dirs = getResolvedIndexedDirectories();
+    static const QStringList dirs = getResolvedIndexedDirectories();
 
     if (dirs.isEmpty()) {
         return QStringList();
@@ -615,7 +615,7 @@ bool isPathInContentIndexDirectory(const QString &path)
     if (!isContentIndexAvailable())
         return false;
 
-    static const QStringList &kDirs = DFMSEARCH::Global::defaultIndexedDirectory();
+    static const QStringList kDirs = DFMSEARCH::Global::defaultIndexedDirectory();
     return isPathInAnyDirectory(path, kDirs);
 }
 
@@ -673,7 +673,7 @@ bool isPathInOcrTextIndexDirectory(const QString &path)
     if (!isOcrTextIndexAvailable())
         return false;
 
-    static const QStringList &kDirs = DFMSEARCH::Global::defaultIndexedDirectory();
+    static const QStringList kDirs = DFMSEARCH::Global::defaultIndexedDirectory();
     return isPathInAnyDirectory(path, kDirs);
 }
 
@@ -714,11 +714,11 @@ bool isPathInFileNameIndexDirectory(const QString &path)
     if (!isFileNameIndexDirectoryAvailable())
         return false;
 
-    static const QStringList &kBlackPaths = defaultBlacklistPaths();
+    static const QStringList kBlackPaths = defaultBlacklistPaths();
     if (BlacklistMatcher::isPathBlacklisted(path, kBlackPaths))
         return false;
 
-    static const QStringList &kIndexedDirs = DFMSEARCH::Global::defaultIndexedDirectory();
+    static const QStringList kIndexedDirs = DFMSEARCH::Global::defaultIndexedDirectory();
     return isPathInAnyDirectory(path, kIndexedDirs);
 }
 


### PR DESCRIPTION
Made the `dirs` variable in `defaultIndexedDirectory()` static const so that `getResolvedIndexedDirectories()` is only called once. This avoids redundant directory resolution on every invocation of the default indexed directory lookup.

将`defaultIndexedDirectory()`中的`dirs`变量声明为static const， 使`getResolvedIndexedDirectories()`仅被调用一次，避免每次查找默认
索引目录时重复进行目录解析。

Log: 缓存已解析的索引目录避免重复解析
PMS: https://pms.uniontech.com/bug-view-361809.html
Influence: 减少重复调用时的冗余文件系统操作，提升频繁查询默认索引目录的搜索场景性能。需确认应用重启后仍能正确加载索引目录配置变更，以及静态初始化不存在线程安全问题。