### PR TITLE
fix: change search worker connection to direct

### DIFF
--- a/src/dfm-search/dfm-search-lib/core/genericsearchengine.cpp
+++ b/src/dfm-search/dfm-search-lib/core/genericsearchengine.cpp
@@ -53,7 +53,7 @@ void GenericSearchEngine::init()
     connect(this, &GenericSearchEngine::requestSearch,
             m_worker, &SearchWorker::doSearch);
     connect(this, &GenericSearchEngine::requestCancel,
-            m_worker, &SearchWorker::cancelSearch);
+            m_worker, &SearchWorker::cancelSearch, Qt::DirectConnection);
 
     // 连接结果信号（工作线程 -> 主线程）
     connect(m_worker, &SearchWorker::resultFound,


### PR DESCRIPTION
1. Modified the connection type between GenericSearchEngine and
SearchWorker for cancel request from default to Qt::DirectConnection
2. This ensures immediate execution of cancel search operations instead
of being queued in event loop

Log: Improved search cancellation responsiveness

Influence:
1. Test search cancellation in various scenarios
2. Verify immediate termination of search operations
3. Check for any potential threading issues with direct connection

fix: 将搜索工作线程连接改为直接连接

1. 将GenericSearchEngine与SearchWorker之间的取消请求连接类型从默认改为
Qt::DirectConnection
2. 这确保了立即执行取消搜索操作而不是排队到事件循环中

Log: 改进了搜索取消的响应速度

Influence:
1. 在各种场景下测试搜索取消功能
2. 验证搜索操作是否能立即终止
3. 检查直接连接可能带来的线程问题
