### PR TITLE
fix(test): replace removed NGramAnalyzer with ChineseAnalyzer

### DIFF
--- a/autotests/dfm-search-tests/tst_content_search_engine.cpp
+++ b/autotests/dfm-search-tests/tst_content_search_engine.cpp
@@ -20,7 +20,7 @@
 #include <lucene++/Field.h>
 #include <lucene++/IndexWriter.h>
 #include <lucene++/LuceneHeaders.h>
-#include <lucene++/NGramAnalyzer.h>
+#include <lucene++/ChineseAnalyzer.h>
 
 using namespace DFMSEARCH;
 using namespace Lucene;
@@ -92,7 +92,7 @@ void createContentIndex(const QString &indexDir, const QList<TestDocument> &docu
 
     IndexWriterPtr writer = newLucene<IndexWriter>(
             FSDirectory::open(indexDir.toStdWString()),
-            newLucene<NGramAnalyzer>(1, 2),
+            newLucene<ChineseAnalyzer>(),
             true,
             IndexWriter::MaxFieldLengthLIMITED);
 
@@ -109,7 +109,7 @@ void createOcrIndex(const QString &indexDir, const QList<TestDocument> &document
 
     IndexWriterPtr writer = newLucene<IndexWriter>(
             FSDirectory::open(indexDir.toStdWString()),
-            newLucene<NGramAnalyzer>(1, 2),
+            newLucene<ChineseAnalyzer>(),
             true,
             IndexWriter::MaxFieldLengthLIMITED);
 

--- a/autotests/dfm-search-tests/tst_filename_search_engine.cpp
+++ b/autotests/dfm-search-tests/tst_filename_search_engine.cpp
@@ -21,7 +21,7 @@
 #include <lucene++/Field.h>
 #include <lucene++/IndexWriter.h>
 #include <lucene++/LuceneHeaders.h>
-#include <lucene++/NGramAnalyzer.h>
+#include <lucene++/ChineseAnalyzer.h>
 #include <lucene++/NumericField.h>
 
 using namespace DFMSEARCH;
@@ -113,7 +113,7 @@ void createFileNameIndex(const QString &indexDir, const QList<TestDocument> &doc
 
     IndexWriterPtr writer = newLucene<IndexWriter>(
             FSDirectory::open(indexDir.toStdWString()),
-            newLucene<NGramAnalyzer>(1, 2),
+            newLucene<ChineseAnalyzer>(),
             true,
             IndexWriter::MaxFieldLengthLIMITED);
 


### PR DESCRIPTION
Upstream lucene++ has completely removed the NGram analyzer module (including NGramAnalyzer.h) in recent versions, causing compilation failures in autotests (`tst_content_search_engine.cpp` and `tst_filename_search_engine.cpp`).

Since these are integrated autotests for index writers and search engines, switch the default analyzer from `NGramAnalyzer(1, 2)` to `ChineseAnalyzer`. This preserves basic tokenization verification for testing purposes while fixing the build breakout against newer lucene++ development headers.

## Summary by Sourcery

Bug Fixes:
- Fix autotest build failures by replacing references to the removed NGramAnalyzer with ChineseAnalyzer in content and filename search engine tests.