### PR TITLE
fix: simplify file timestamp attribute handling

### DIFF
--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -114,7 +114,7 @@ void DFileInfoPrivate::initNormal()
         return;
 
     const QUrl &url = q->uri();
-    this->gfile = DLocalHelper::createGFile(url);;
+    this->gfile = DLocalHelper::createGFile(url);
 }
 
 void DFileInfoPrivate::attributeExtend(DFileInfo::MediaType type, QList<DFileInfo::AttributeExtendID> ids, DFileInfo::AttributeExtendFuncCallback callback)
@@ -304,9 +304,7 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             if (ret != 0)
                 return QVariant();
 
-            return statxBuffer.stx_btime.tv_sec > 0
-                    ? quint64(statxBuffer.stx_btime.tv_sec)
-                    : quint64(statxBuffer.stx_ctime.tv_sec);
+            return quint64(statxBuffer.stx_btime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -325,9 +323,7 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             if (ret != 0)
                 return QVariant();
 
-            return statxBuffer.stx_btime.tv_nsec > 0
-                    ? statxBuffer.stx_btime.tv_nsec / 1000000
-                    : statxBuffer.stx_ctime.tv_nsec / 1000000;
+            return statxBuffer.stx_btime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }
@@ -346,9 +342,7 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             if (ret != 0)
                 return QVariant();
 
-            return statxBuffer.stx_mtime.tv_sec > 0
-                    ? quint64(statxBuffer.stx_mtime.tv_sec)
-                    : quint64(statxBuffer.stx_ctime.tv_sec);
+            return quint64(statxBuffer.stx_mtime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -367,9 +361,7 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             if (ret != 0)
                 return QVariant();
 
-            return statxBuffer.stx_mtime.tv_nsec > 0
-                    ? statxBuffer.stx_mtime.tv_nsec / 1000000
-                    : statxBuffer.stx_ctime.tv_nsec / 1000000;
+            return statxBuffer.stx_mtime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }
@@ -388,9 +380,7 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             if (ret != 0)
                 return QVariant();
 
-            return statxBuffer.stx_atime.tv_sec > 0
-                    ? quint64(statxBuffer.stx_atime.tv_sec)
-                    : quint64(statxBuffer.stx_ctime.tv_sec);
+            return quint64(statxBuffer.stx_atime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -409,9 +399,7 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             if (ret != 0)
                 return QVariant();
 
-            return statxBuffer.stx_atime.tv_nsec > 0
-                    ? statxBuffer.stx_atime.tv_nsec / 1000000
-                    : statxBuffer.stx_ctime.tv_nsec / 1000000;
+            return statxBuffer.stx_atime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }


### PR DESCRIPTION
1. Removed fallback to ctime when checking file timestamps (btime/mtime/
atime)
2. Simplified ternary operations to directly use the respective
timestamp values
3. Fixed a duplicate semicolon in file initialization code

The changes streamline the file timestamp attribute handling by removing
redundant fallback checks to ctime. The original implementation would
fall back to ctime if the primary timestamp was 0, but this behavior
was unnecessary and could cause confusion. The timestamps are now
directly read from their respective fields (btime, mtime, atime) without
fallback.

Influence:
1. Verify file creation/modification/access timestamps are correctly
reported
2. Test with files that have valid timestamps in all fields
3. Check behavior with files that might have 0 values in timestamp
fields
4. Verify no regression in file information display functionality

fix: 简化文件时间戳属性处理

1. 移除了检查文件时间戳(btime/mtime/atime)时回退到ctime的处理
2. 简化了三元运算符，直接使用相应时间戳值
3. 修复了文件初始化代码中的重复分号问题

这些更改通过移除对ctime的冗余回退检查简化了文件时间戳属性处理。原实现会
在主时间戳为0时回退到ctime，但这种行为是不必要的且可能导致混淆。现在时间
戳直接从各自字段(btime, mtime, atime)读取而无需回退。

Influence:
1. 验证文件创建/修改/访问时间戳是否正确显示
2. 测试具有所有字段有效时间戳的文件
3. 检查时间戳字段为0时的处理行为
4. 验证文件信息显示功能没有退化

Fixes: #365719
