### PR TITLE
feat: expand supported file extensions for search

### DIFF
--- a/autotests/dfm-search-tests/tst_chinese_nlp.cpp
+++ b/autotests/dfm-search-tests/tst_chinese_nlp.cpp
@@ -26,6 +26,44 @@ static bool setEquals(const QStringList &a, const QStringList &b)
     return QSet<QString>(a.begin(), a.end()) == QSet<QString>(b.begin(), b.end());
 }
 
+namespace {
+
+// Keep these lists in sync with filetype_rules.json extensions.
+QStringList imageExpectedExts()
+{
+    return QStringList{
+        "ani","avif","avifs","bmp","bw","dci","eps","epsf","epsi","exr","gif",
+        "heic","heif","heis","heix","icns","ico","jpe","jpeg","jpg","kra","mng",
+        "ora","pcx","pic","png","psd","raf","ras","raw","rgb","rgba","sgi","svg",
+        "svgz","tga","tif","tiff","wbmp","webp","wmf","xcf","cr2","crw","nef","dng",
+        "arw","orf","rw2","pef","srw","mrw","x3f","dcr","kdc","3fr","nrw","mef","iiq",
+        "sr2","erf","mos","rwl"
+    };
+}
+
+QStringList videoExpectedExts()
+{
+    return QStringList{
+        "3g2","3gp","3gp2","3gpp","amr","amv","asf","asx","avi","bdmv","bik","d2v",
+        "divx","drc","dsa","dsm","dss","dsv","evo","f4v","flc","fli","flic","flv",
+        "hdmov","ifo","ivf","m1v","m2p","m2t","m2ts","m2v","m4b","m4p","m4v","mkv",
+        "mp2v","mp4","mp4v","mpe","mpeg","mpg","mpls","mpv2","mpv4","mov","mts","ogm",
+        "ogv","pss","pva","qt","ram","ratdvd","rm","rmm","rmvb","roq","rpm","smil","smk",
+        "swf","tp","tpr","ts","vob","vp6","webm","wm","wmp","wmv"
+    };
+}
+
+QStringList audioExpectedExts()
+{
+    return QStringList{
+        "aac","ac3","aif","aifc","aiff","au","cda","dts","fla","flac","it","m1a",
+        "m2a","m3u","m4a","mid","midi","mka","mod","mp2","mp3","mpa","ogg","opus",
+        "ra","rmi","spc","snd","umx","voc","wav","wma","xm","ape"
+    };
+}
+
+} // namespace
+
 class tst_ChineseNLP : public QObject
 {
     Q_OBJECT
@@ -428,7 +466,7 @@ void tst_ChineseNLP::fileType_category_image_variants()
                                  QStringLiteral("截图"), QStringLiteral("壁纸"),
                                  QStringLiteral("海报"), QStringLiteral("相片"),
                                  QStringLiteral("表情包"), QStringLiteral("图") };
-    const QStringList expectedExts = { "jpg", "jpeg", "png", "gif", "bmp", "webp", "svg" };
+    const QStringList expectedExts = imageExpectedExts();
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
@@ -442,7 +480,7 @@ void tst_ChineseNLP::fileType_category_video_variants()
     const QStringList inputs = { QStringLiteral("视频"), QStringLiteral("录像"),
                                  QStringLiteral("电影"), QStringLiteral("动画"),
                                  QStringLiteral("短片"), QStringLiteral("片子") };
-    const QStringList expectedExts = { "mp4", "avi", "mkv", "mov", "flv", "wmv", "webm" };
+    const QStringList expectedExts = videoExpectedExts();
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
@@ -456,7 +494,7 @@ void tst_ChineseNLP::fileType_category_audio_variants()
     const QStringList inputs = { QStringLiteral("音频"), QStringLiteral("音乐"),
                                  QStringLiteral("录音"), QStringLiteral("歌"),
                                  QStringLiteral("语音") };
-    const QStringList expectedExts = { "mp3", "wav", "flac", "aac", "ogg", "m4a" };
+    const QStringList expectedExts = audioExpectedExts();
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
@@ -470,7 +508,7 @@ void tst_ChineseNLP::fileType_category_archive()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("压缩包"), intent);
     QVERIFY(intent.fileExtensions.contains("zip"));
-    QVERIFY(intent.fileExtensions.contains("tar.gz"));
+    QVERIFY(intent.fileExtensions.contains("gz"));
     QVERIFY(intent.fileExtensions.contains("rar"));
     QVERIFY(intent.fileExtensions.contains("7z"));
 }
@@ -606,7 +644,7 @@ void tst_ChineseNLP::combined_timeAndFiletype()
     m_parser->parse(QStringLiteral("今天的图片"), intent);
     QCOMPARE(intent.timeConstraint.kind, TimeConstraintKind::Preset);
     QCOMPARE(intent.timeConstraint.preset, TimePreset::Today);
-    const QStringList imageExts = { "jpg", "jpeg", "png", "gif", "bmp", "webp", "svg" };
+    const QStringList imageExts = imageExpectedExts();
     QVERIFY(setEquals(intent.fileExtensions, imageExts));
     // "的" is consumed by noise_suffix "的图片"
     QVERIFY(intent.keywords.isEmpty());
@@ -963,7 +1001,7 @@ void tst_ChineseNLP::fileType_image_allSynonyms()
         QStringLiteral("图"), QStringLiteral("壁纸"), QStringLiteral("海报"),
         QStringLiteral("相片"), QStringLiteral("表情包")
     };
-    const QStringList expectedExts = { "jpg", "jpeg", "png", "gif", "bmp", "webp", "svg" };
+    const QStringList expectedExts = imageExpectedExts();
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
@@ -979,7 +1017,7 @@ void tst_ChineseNLP::fileType_video_allSynonyms()
         QStringLiteral("视频"), QStringLiteral("录像"), QStringLiteral("电影"),
         QStringLiteral("动画"), QStringLiteral("短片"), QStringLiteral("片子")
     };
-    const QStringList expectedExts = { "mp4", "avi", "mkv", "mov", "flv", "wmv", "webm" };
+    const QStringList expectedExts = videoExpectedExts();
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
@@ -995,7 +1033,7 @@ void tst_ChineseNLP::fileType_audio_allSynonyms()
         QStringLiteral("音频"), QStringLiteral("音乐"), QStringLiteral("录音"),
         QStringLiteral("歌"), QStringLiteral("语音")
     };
-    const QStringList expectedExts = { "mp3", "wav", "flac", "aac", "ogg", "m4a" };
+    const QStringList expectedExts = audioExpectedExts();
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);

--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/filetype_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/filetype_rules.json
@@ -90,7 +90,7 @@
                     "enabled": true,
                     "priority": 150,
                     "metadata": {
-                        "extensions": ["jpg", "jpeg", "png", "gif", "bmp", "webp", "svg"],
+                        "extensions": ["ani","avif","avifs","bmp","bw","dci","eps","epsf","epsi","exr","gif","heic","heif","heis","heix","icns","ico","jpe","jpeg","jpg","kra","mng","ora","pcx","pic","png","psd","raf","ras","raw","rgb","rgba","sgi","svg","svgz","tga","tif","tiff","wbmp","webp","wmf","xcf","cr2","crw","nef","dng","arw","orf","rw2","pef","srw","mrw","x3f","dcr","kdc","3fr","nrw","mef","iiq","sr2","erf","mos","rwl"],
                         "fileTypes": ["pic"]
                     }
                 },
@@ -101,7 +101,7 @@
                     "enabled": true,
                     "priority": 150,
                     "metadata": {
-                        "extensions": ["mp4", "avi", "mkv", "mov", "flv", "wmv", "webm"],
+                        "extensions": ["3g2","3gp","3gp2","3gpp","amr","amv","asf","asx","avi","bdmv","bik","d2v","divx","drc","dsa","dsm","dss","dsv","evo","f4v","flc","fli","flic","flv","hdmov","ifo","ivf","m1v","m2p","m2t","m2ts","m2v","m4b","m4p","m4v","mkv","mp2v","mp4","mp4v","mpe","mpeg","mpg","mpls","mpv2","mpv4","mov","mts","ogm","ogv","pss","pva","qt","ram","ratdvd","rm","rmm","rmvb","roq","rpm","smil","smk","swf","tp","tpr","ts","vob","vp6","webm","wm","wmp","wmv"],
                         "fileTypes": ["video"]
                     }
                 },
@@ -112,7 +112,7 @@
                     "enabled": true,
                     "priority": 150,
                     "metadata": {
-                        "extensions": ["mp3", "wav", "flac", "aac", "ogg", "m4a"],
+                        "extensions": ["aac","ac3","aif","aifc","aiff","au","cda","dts","fla","flac","it","m1a","m2a","m3u","m4a","mid","midi","mka","mod","mp2","mp3","mpa","ogg","opus","ra","rmi","spc","snd","umx","voc","wav","wma","xm","ape"],
                         "fileTypes": ["audio"]
                     }
                 },
@@ -123,7 +123,7 @@
                     "enabled": true,
                     "priority": 150,
                     "metadata": {
-                        "extensions": ["zip", "tar.gz", "tar", "rar", "7z", "bz2"],
+                        "extensions": ["7z","ace","arj","bz2","cab","gz","gzip","jar","r00","r01","r02","r03","r04","r05","r06","r07","r08","r09","r10","r11","r12","r13","r14","r15","r16","r17","r18","r19","r20","r21","r22","r23","r24","r25","r26","r27","r28","r29","rar","tar","tgz","z","zip"],
                         "fileTypes": ["archive"]
                     }
                 },
@@ -134,7 +134,7 @@
                     "enabled": true,
                     "priority": 150,
                     "metadata": {
-                        "extensions": ["deb", "AppImage", "sh", "py", "bin", "run"],
+                        "extensions": ["deb", "AppImage", "sh", "py", "bin", "run", "desktop"],
                         "fileTypes": ["app"]
                     }
                 },


### PR DESCRIPTION
1. Significantly expanded the list of supported file extensions for
image, video, audio and archive file types in Chinese NLP search
2. Added many modern and professional format extensions like AVIF, HEIC,
CR2 (RAW photos) for images
3. Included more video formats like BDMV, MTS, VOB for professional
video workflows
4. Added audio formats like FLAC variants, MIDI, mod tracker formats
5. Improved archive support with more formats like ACE, ARJ, CAB
6. Also updated the test cases to match the new extension lists

Influence:
1. Test searching for various image formats including raw camera formats
2. Verify video search recognizes professional and less common formats
3. Check audio search for lossless and tracker formats
4. Validate archive file recognition with all new supported extensions
5. Test desktop file search functionality as it was newly added

feat: 扩展搜索支持的文件扩展名列表

1. 大幅扩展中文NLP搜索支持的图片、视频、音频和压缩包文件扩展名
2. 为图片新增现代和专业格式支持如AVIF、HEIC、CR2(RAW格式)
3. 包含更多专业视频格式如BDMV、MTS、VOB
4. 添加音频格式支持包括FLAC变体、MIDI和mod跟踪器格式
5. 改进压缩包支持增加ACE、ARJ、CAB等格式
6. 同步更新了测试用例以适应新的扩展名列表

Influence:
1. 测试搜索各种图片格式包括RAW相机格式
2. 验证视频搜索识别专业和较少见的格式
3. 检查音频搜索对无损和跟踪器格式的支持
4. 测试所有新增支持的压缩包文件识别
5. 验证新增的desktop文件搜索功能

## Summary by Sourcery

Expand Chinese NLP search filetype coverage for media and archives and align tests with the updated extension lists.

New Features:
- Broaden image search support to include modern formats and numerous RAW camera extensions.
- Extend video search support to cover a wide range of consumer and professional video formats.
- Enhance audio search support with additional lossless, playlist, MIDI, and tracker-style audio extensions.
- Increase archive search coverage by recognizing gzip archives explicitly in addition to existing formats.

Tests:
- Update Chinese NLP search tests to validate the expanded image, video, audio, and archive extension sets.