### PR TITLE
refactor: update semantic search rules and tests

### DIFF
--- a/autotests/dfm-search-tests/main.cpp
+++ b/autotests/dfm-search-tests/main.cpp
@@ -19,6 +19,7 @@ extern QObject *create_tst_SizeRangeFilter();
 extern QObject *create_tst_IsSemanticQuery();
 extern QObject *create_tst_SearchTarget();
 extern QObject *create_tst_SemanticQueryBuilderTarget();
+extern QObject *create_tst_LocationExtraction();
 extern QObject *create_tst_ContentRetriever();
 extern QObject *create_tst_ContentSearchEngine();
 extern QObject *create_tst_FileNameSearchEngine();
@@ -83,6 +84,10 @@ int main(int argc, char *argv[])
     QObject *testObj14 = create_tst_SemanticQueryBuilderTarget();
     result |= QTest::qExec(testObj14, argc, argv);
     delete testObj14;
+
+    QObject *testObj14b = create_tst_LocationExtraction();
+    result |= QTest::qExec(testObj14b, argc, argv);
+    delete testObj14b;
 
     QObject *testObj15 = create_tst_ContentRetriever();
     result |= QTest::qExec(testObj15, argc, argv);

--- a/autotests/dfm-search-tests/tst_chinese_nlp.cpp
+++ b/autotests/dfm-search-tests/tst_chinese_nlp.cpp
@@ -31,38 +31,38 @@ namespace {
 // Keep these lists in sync with filetype_rules.json extensions.
 QStringList imageExpectedExts()
 {
-    return QStringList{
-        "ani","avif","avifs","bmp","bw","dci","eps","epsf","epsi","exr","gif",
-        "heic","heif","heis","heix","icns","ico","jpe","jpeg","jpg","kra","mng",
-        "ora","pcx","pic","png","psd","raf","ras","raw","rgb","rgba","sgi","svg",
-        "svgz","tga","tif","tiff","wbmp","webp","wmf","xcf","cr2","crw","nef","dng",
-        "arw","orf","rw2","pef","srw","mrw","x3f","dcr","kdc","3fr","nrw","mef","iiq",
-        "sr2","erf","mos","rwl"
+    return QStringList {
+        "ani", "avif", "avifs", "bmp", "bw", "dci", "eps", "epsf", "epsi", "exr", "gif",
+        "heic", "heif", "heis", "heix", "icns", "ico", "jpe", "jpeg", "jpg", "kra", "mng",
+        "ora", "pcx", "pic", "png", "psd", "raf", "ras", "raw", "rgb", "rgba", "sgi", "svg",
+        "svgz", "tga", "tif", "tiff", "wbmp", "webp", "wmf", "xcf", "cr2", "crw", "nef", "dng",
+        "arw", "orf", "rw2", "pef", "srw", "mrw", "x3f", "dcr", "kdc", "3fr", "nrw", "mef", "iiq",
+        "sr2", "erf", "mos", "rwl"
     };
 }
 
 QStringList videoExpectedExts()
 {
-    return QStringList{
-        "3g2","3gp","3gp2","3gpp","amr","amv","asf","asx","avi","bdmv","bik","d2v",
-        "divx","drc","dsa","dsm","dss","dsv","evo","f4v","flc","fli","flic","flv",
-        "hdmov","ifo","ivf","m1v","m2p","m2t","m2ts","m2v","m4b","m4p","m4v","mkv",
-        "mp2v","mp4","mp4v","mpe","mpeg","mpg","mpls","mpv2","mpv4","mov","mts","ogm",
-        "ogv","pss","pva","qt","ram","ratdvd","rm","rmm","rmvb","roq","rpm","smil","smk",
-        "swf","tp","tpr","ts","vob","vp6","webm","wm","wmp","wmv"
+    return QStringList {
+        "3g2", "3gp", "3gp2", "3gpp", "amr", "amv", "asf", "asx", "avi", "bdmv", "bik", "d2v",
+        "divx", "drc", "dsa", "dsm", "dss", "dsv", "evo", "f4v", "flc", "fli", "flic", "flv",
+        "hdmov", "ifo", "ivf", "m1v", "m2p", "m2t", "m2ts", "m2v", "m4b", "m4p", "m4v", "mkv",
+        "mp2v", "mp4", "mp4v", "mpe", "mpeg", "mpg", "mpls", "mpv2", "mpv4", "mov", "mts", "ogm",
+        "ogv", "pss", "pva", "qt", "ram", "ratdvd", "rm", "rmm", "rmvb", "roq", "rpm", "smil", "smk",
+        "swf", "tp", "tpr", "ts", "vob", "vp6", "webm", "wm", "wmp", "wmv"
     };
 }
 
 QStringList audioExpectedExts()
 {
-    return QStringList{
-        "aac","ac3","aif","aifc","aiff","au","cda","dts","fla","flac","it","m1a",
-        "m2a","m3u","m4a","mid","midi","mka","mod","mp2","mp3","mpa","ogg","opus",
-        "ra","rmi","spc","snd","umx","voc","wav","wma","xm","ape"
+    return QStringList {
+        "aac", "ac3", "aif", "aifc", "aiff", "au", "cda", "dts", "fla", "flac", "it", "m1a",
+        "m2a", "m3u", "m4a", "mid", "midi", "mka", "mod", "mp2", "mp3", "mpa", "ogg", "opus",
+        "ra", "rmi", "spc", "snd", "umx", "voc", "wav", "wma", "xm", "ape"
     };
 }
 
-} // namespace
+}   // namespace
 
 class tst_ChineseNLP : public QObject
 {
@@ -201,8 +201,6 @@ private Q_SLOTS:
     void location_picturesDir();
     void location_musicDir();
     void location_videosDir();
-    void location_trash();
-    void location_deleted();
     void location_noLocation();
     void location_desktopAndDownload();
 
@@ -1772,35 +1770,6 @@ void tst_ChineseNLP::location_videosDir()
     m_parser->parse(QStringLiteral("视频目录下的电影"), intent);
     QCOMPARE(intent.searchDirectories.size(), 1);
     QCOMPARE(intent.searchDirectories.first(), videosPath);
-}
-
-void tst_ChineseNLP::location_trash()
-{
-    // "回收站里的文件" → location(trash) + includeHidden + filetype(文件=文档类)
-    const QString trashPath = QDir::homePath() + "/.local/share/Trash/files";
-    ParsedIntent intent;
-    m_parser->parse(QStringLiteral("回收站里的文档"), intent);
-    QCOMPARE(intent.searchDirectories.size(), 1);
-    QCOMPARE(intent.searchDirectories.first(), trashPath);
-    QVERIFY(intent.includeHidden);
-    // "文件" matches filetype_document_general, so it's a filetype not a keyword
-    QVERIFY(!intent.fileExtensions.isEmpty());
-    QVERIFY(intent.fileExtensions.contains("doc"));
-    QVERIFY(intent.keywords.isEmpty());
-}
-
-void tst_ChineseNLP::location_deleted()
-{
-    // "昨天删除的音乐" → location(trash) + time(yesterday) + filetype(音乐)
-    const QString trashPath = QDir::homePath() + "/.local/share/Trash/files";
-    ParsedIntent intent;
-    m_parser->parse(QStringLiteral("昨天删除的音乐"), intent);
-    QCOMPARE(intent.searchDirectories.size(), 1);
-    QCOMPARE(intent.searchDirectories.first(), trashPath);
-    QVERIFY(intent.includeHidden);
-    QCOMPARE(intent.timeConstraint.kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint.preset, TimePreset::Yesterday);
-    QVERIFY(intent.fileExtensions.contains("mp3"));
 }
 
 void tst_ChineseNLP::location_noLocation()

--- a/autotests/dfm-search-tests/tst_semantic_search.cpp
+++ b/autotests/dfm-search-tests/tst_semantic_search.cpp
@@ -8,6 +8,8 @@
 #include <QJsonArray>
 #include <QDateTime>
 #include <QCoreApplication>
+#include <QDir>
+#include <QFile>
 
 #include <dfm-search/semanticsearcher.h>
 
@@ -16,6 +18,7 @@
 #include "semantic/ruleconfigloader.h"
 #include "semantic/extractors/keywordextractor.h"
 #include "semantic/semanticquerybuilder.h"
+#include "semantic/extractors/locationextractor.h"
 
 using namespace DFMSEARCH;
 
@@ -50,10 +53,10 @@ static QByteArray makeRuleJson(const QString &groupName, const QString &ruleId,
     QJsonObject ruleGroupObj;
     ruleGroupObj["name"] = groupName;
     ruleGroupObj["version"] = "1.0.0";
-    ruleGroupObj["rules"] = QJsonArray({ruleObj});
+    ruleGroupObj["rules"] = QJsonArray({ ruleObj });
 
     QJsonObject root;
-    root["groups"] = QJsonArray({ruleGroupObj});
+    root["groups"] = QJsonArray({ ruleGroupObj });
 
     return QJsonDocument(root).toJson(QJsonDocument::Compact);
 }
@@ -97,17 +100,23 @@ void tst_RuleEngine::parseEmptyGroup()
 void tst_RuleEngine::parsePriorityOrdering()
 {
     QJsonObject r1, r2, r3;
-    r1["id"] = "low";  r1["pattern"] = "test"; r1["priority"] = 10;
-    r2["id"] = "high"; r2["pattern"] = "test"; r2["priority"] = 200;
-    r3["id"] = "mid";  r3["pattern"] = "test"; r3["priority"] = 100;
+    r1["id"] = "low";
+    r1["pattern"] = "test";
+    r1["priority"] = 10;
+    r2["id"] = "high";
+    r2["pattern"] = "test";
+    r2["priority"] = 200;
+    r3["id"] = "mid";
+    r3["pattern"] = "test";
+    r3["priority"] = 100;
 
     QJsonObject ruleGroup;
     ruleGroup["name"] = "prio";
     ruleGroup["version"] = "1.0.0";
-    ruleGroup["rules"] = QJsonArray({r1, r2, r3});
+    ruleGroup["rules"] = QJsonArray({ r1, r2, r3 });
 
     QJsonObject root;
-    root["groups"] = QJsonArray({ruleGroup});
+    root["groups"] = QJsonArray({ ruleGroup });
 
     RuleGroup group;
     QVERIFY(SemanticRuleEngine::parseRuleGroupStatic(ruleGroup, group));
@@ -125,7 +134,7 @@ void tst_RuleEngine::parsePriorityOrdering()
 void tst_RuleEngine::matchReturnsHighestPriority()
 {
     QByteArray json = makeRuleJson("test_match", "r1", "abc", 200,
-                                   {{"level", "high"}});
+                                   { { "level", "high" } });
 
     RuleGroup group;
     QVERIFY(buildGroupFromJson(json, group));
@@ -135,17 +144,23 @@ void tst_RuleEngine::matchReturnsHighestPriority()
 void tst_RuleEngine::matchAllReturnsAll()
 {
     QJsonObject r1, r2, r3;
-    r1["id"] = "r1"; r1["pattern"] = "cat"; r1["priority"] = 100;
-    r2["id"] = "r2"; r2["pattern"] = "dog"; r2["priority"] = 100;
-    r3["id"] = "r3"; r3["pattern"] = "bird"; r3["priority"] = 50;
+    r1["id"] = "r1";
+    r1["pattern"] = "cat";
+    r1["priority"] = 100;
+    r2["id"] = "r2";
+    r2["pattern"] = "dog";
+    r2["priority"] = 100;
+    r3["id"] = "r3";
+    r3["pattern"] = "bird";
+    r3["priority"] = 50;
 
     QJsonObject ruleGroup;
     ruleGroup["name"] = "test_all";
     ruleGroup["version"] = "1.0.0";
-    ruleGroup["rules"] = QJsonArray({r1, r2, r3});
+    ruleGroup["rules"] = QJsonArray({ r1, r2, r3 });
 
     QJsonObject root;
-    root["groups"] = QJsonArray({ruleGroup});
+    root["groups"] = QJsonArray({ ruleGroup });
 
     RuleGroup group;
     QVERIFY(SemanticRuleEngine::parseRuleGroupStatic(ruleGroup, group));
@@ -358,20 +373,20 @@ private Q_SLOTS:
 void tst_FileTypeExtraction::precisePdf()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"pdf"});
+    meta["extensions"] = QStringList({ "pdf" });
     QByteArray json = makeRuleJson("filetype", "filetype_pdf", "pdf", 200, meta);
 
     RuleGroup group;
     QVERIFY(buildGroupFromJson(json, group));
     QVERIFY(group.rules[0].regex.match("pdf").hasMatch());
-    QCOMPARE(group.rules[0].metadata.value("extensions").toStringList(), QStringList({"pdf"}));
+    QCOMPARE(group.rules[0].metadata.value("extensions").toStringList(), QStringList({ "pdf" }));
 }
 
 void tst_FileTypeExtraction::preciseWord()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"doc", "docx"});
-    meta["fileTypes"] = QStringList({"doc"});
+    meta["extensions"] = QStringList({ "doc", "docx" });
+    meta["fileTypes"] = QStringList({ "doc" });
     QByteArray json = makeRuleJson("filetype", "filetype_word", "word|doc|docx", 200, meta);
 
     RuleGroup group;
@@ -384,7 +399,7 @@ void tst_FileTypeExtraction::preciseWord()
 void tst_FileTypeExtraction::preciseExcel()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"xls", "xlsx"});
+    meta["extensions"] = QStringList({ "xls", "xlsx" });
     QByteArray json = makeRuleJson("filetype", "filetype_excel", "excel|xls|xlsx", 200, meta);
 
     RuleGroup group;
@@ -396,7 +411,7 @@ void tst_FileTypeExtraction::preciseExcel()
 void tst_FileTypeExtraction::precisePpt()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"ppt", "pptx"});
+    meta["extensions"] = QStringList({ "ppt", "pptx" });
     QByteArray json = makeRuleJson("filetype", "filetype_ppt", "ppt|pptx", 200, meta);
 
     RuleGroup group;
@@ -408,44 +423,44 @@ void tst_FileTypeExtraction::precisePpt()
 void tst_FileTypeExtraction::imageType()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"jpg", "png", "gif"});
-    meta["fileTypes"] = QStringList({"pic"});
+    meta["extensions"] = QStringList({ "jpg", "png", "gif" });
+    meta["fileTypes"] = QStringList({ "pic" });
     QByteArray json = makeRuleJson("filetype", "filetype_image", "image", 150, meta);
 
     RuleGroup group;
     QVERIFY(buildGroupFromJson(json, group));
-    QCOMPARE(group.rules[0].metadata.value("fileTypes").toStringList(), QStringList({"pic"}));
+    QCOMPARE(group.rules[0].metadata.value("fileTypes").toStringList(), QStringList({ "pic" }));
 }
 
 void tst_FileTypeExtraction::videoType()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"mp4", "avi", "mkv"});
-    meta["fileTypes"] = QStringList({"video"});
+    meta["extensions"] = QStringList({ "mp4", "avi", "mkv" });
+    meta["fileTypes"] = QStringList({ "video" });
     QByteArray json = makeRuleJson("filetype", "filetype_video", "video", 150, meta);
 
     RuleGroup group;
     QVERIFY(buildGroupFromJson(json, group));
-    QCOMPARE(group.rules[0].metadata.value("fileTypes").toStringList(), QStringList({"video"}));
+    QCOMPARE(group.rules[0].metadata.value("fileTypes").toStringList(), QStringList({ "video" }));
 }
 
 void tst_FileTypeExtraction::audioType()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"mp3", "wav", "flac"});
-    meta["fileTypes"] = QStringList({"audio"});
+    meta["extensions"] = QStringList({ "mp3", "wav", "flac" });
+    meta["fileTypes"] = QStringList({ "audio" });
     QByteArray json = makeRuleJson("filetype", "filetype_audio", "audio", 150, meta);
 
     RuleGroup group;
     QVERIFY(buildGroupFromJson(json, group));
-    QCOMPARE(group.rules[0].metadata.value("fileTypes").toStringList(), QStringList({"audio"}));
+    QCOMPARE(group.rules[0].metadata.value("fileTypes").toStringList(), QStringList({ "audio" }));
 }
 
 void tst_FileTypeExtraction::genericDocument()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"doc", "docx", "pdf", "txt"});
-    meta["fileTypes"] = QStringList({"doc"});
+    meta["extensions"] = QStringList({ "doc", "docx", "pdf", "txt" });
+    meta["fileTypes"] = QStringList({ "doc" });
     meta["general"] = true;
     QByteArray json = makeRuleJson("filetype", "filetype_document_general", "document", 100, meta);
 
@@ -458,7 +473,7 @@ void tst_FileTypeExtraction::genericDocument()
 void tst_FileTypeExtraction::genericSpreadsheet()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"xls", "xlsx", "csv"});
+    meta["extensions"] = QStringList({ "xls", "xlsx", "csv" });
     meta["general"] = true;
     QByteArray json = makeRuleJson("filetype", "filetype_spreadsheet_general", "spreadsheet", 100, meta);
 
@@ -470,7 +485,7 @@ void tst_FileTypeExtraction::genericSpreadsheet()
 void tst_FileTypeExtraction::genericPresentation()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"ppt", "pptx", "dps"});
+    meta["extensions"] = QStringList({ "ppt", "pptx", "dps" });
     meta["general"] = true;
     QByteArray json = makeRuleJson("filetype", "filetype_presentation_general", "presentation", 100, meta);
 
@@ -482,7 +497,7 @@ void tst_FileTypeExtraction::genericPresentation()
 void tst_FileTypeExtraction::archiveType()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"zip", "tar", "rar", "7z"});
+    meta["extensions"] = QStringList({ "zip", "tar", "rar", "7z" });
     QByteArray json = makeRuleJson("filetype", "filetype_archive", "archive", 150, meta);
 
     RuleGroup group;
@@ -493,7 +508,7 @@ void tst_FileTypeExtraction::archiveType()
 void tst_FileTypeExtraction::extensionsList()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"a", "b", "c", "d", "e"});
+    meta["extensions"] = QStringList({ "a", "b", "c", "d", "e" });
     QByteArray json = makeRuleJson("filetype", "ft", "test", 100, meta);
 
     RuleGroup group;
@@ -504,7 +519,7 @@ void tst_FileTypeExtraction::extensionsList()
 void tst_FileTypeExtraction::generalFlag()
 {
     QVariantMap meta;
-    meta["extensions"] = QStringList({"pdf"});
+    meta["extensions"] = QStringList({ "pdf" });
     QByteArray json = makeRuleJson("filetype", "ft_precise", "pdf", 200, meta);
 
     RuleGroup group;
@@ -679,7 +694,7 @@ bool sourceRulesAvailable()
 {
     const QString dir = sourceRulesDir();
     return QDir(dir).exists()
-            && !QDir(dir).entryList({"*.json"}, QDir::Files).isEmpty();
+            && !QDir(dir).entryList({ "*.json" }, QDir::Files).isEmpty();
 }
 
 // Replicate isSemanticQuery() logic using internal components with source-tree rules.
@@ -718,9 +733,9 @@ private Q_SLOTS:
     void fileTypePdf();
     void fileTypeImage();
     void fileTypeDocument();
+    void locationWechat();
     void locationDesktop();
     void locationDownloads();
-    void locationTrash();
     void sizeLarge();
     void sizeSmall();
     void sizeDynamic();
@@ -729,6 +744,7 @@ private Q_SLOTS:
     void keywordOnlyNoMatch();
     void consecutiveCalls();
     void noiseWordsOnly();
+    void wechatLocationConsumesTriggerWords();
 
 private:
     SemanticRuleEngine *m_engine = nullptr;
@@ -744,7 +760,7 @@ void tst_IsSemanticQuery::initTestCase()
     m_engine = new SemanticRuleEngine(this);
     const QString dir = sourceRulesDir();
     const QStringList ruleFiles = QDir(dir).entryList(
-            {"*.json"}, QDir::Files, QDir::Name);
+            { "*.json" }, QDir::Files, QDir::Name);
     for (const QString &filename : ruleFiles) {
         QString path = dir + "/" + filename;
         if (!m_engine->loadRuleFile(path)) {
@@ -822,6 +838,23 @@ void tst_IsSemanticQuery::fileTypeDocument()
     QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "报告"));
 }
 
+void tst_IsSemanticQuery::locationWechat()
+{
+    // WeChat custom_path uses glob which may match nothing locally,
+    // so verify pattern recognition via consumedSpans instead of searchDirectories.
+    LocationExtractor extractor(m_engine);
+    const QStringList inputs = {
+        "微信的文件", "vx收到的文档", "微信里发给我的",
+        "微信群的文件", "微信接收的压缩包"
+    };
+    for (const QString &input : inputs) {
+        ParsedIntent intent;
+        extractor.extract(input, intent);
+        QVERIFY2(!intent.consumedSpans.isEmpty(),
+                 qUtf8Printable("Expected consumed span for: " + input));
+    }
+}
+
 void tst_IsSemanticQuery::locationDesktop()
 {
     QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "桌面的文件"));
@@ -830,12 +863,6 @@ void tst_IsSemanticQuery::locationDesktop()
 void tst_IsSemanticQuery::locationDownloads()
 {
     QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "下载的文件"));
-}
-
-void tst_IsSemanticQuery::locationTrash()
-{
-    QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "回收站的文件"));
-    QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "删除的文件"));
 }
 
 void tst_IsSemanticQuery::sizeLarge()
@@ -900,6 +927,36 @@ void tst_IsSemanticQuery::noiseWordsOnly()
     QVERIFY(!checkIsSemanticQuery(m_engine, m_parser, "查找"));
 }
 
+void tst_IsSemanticQuery::wechatLocationConsumesTriggerWords()
+{
+    // Verify that location trigger words are fully consumed and do NOT leak
+    // into keywords. Regex alternation must place longer patterns first so that
+    // "微信发我的" wins over "微信", otherwise "发给我" incorrectly becomes a keyword.
+    const struct
+    {
+        const char *input;
+        const char *expectedKeywordNotContaining;   // keyword must NOT contain this
+    } cases[] = {
+        { "微信发给我的文档", "发给我" },
+        { "微信接收的文件", "接收" },
+        { "微信群里发的", "微信群" },
+        { "vx的文件", "vx" },
+    };
+
+    for (const auto &c : cases) {
+        ParsedIntent intent;
+        m_parser->parse(QString::fromUtf8(c.input), intent);
+        // Trigger word itself must not appear as a keyword
+        for (const QString &kw : intent.keywords) {
+            QVERIFY2(!kw.contains(QString::fromUtf8(c.expectedKeywordNotContaining)),
+                     qUtf8Printable(QString("Keyword '%1' should not contain trigger fragment '%2' (input: %3)")
+                                            .arg(kw)
+                                            .arg(c.expectedKeywordNotContaining)
+                                            .arg(c.input)));
+        }
+    }
+}
+
 // ===== tst_SearchTarget =====
 
 class tst_SearchTarget : public QObject
@@ -929,7 +986,7 @@ void tst_SearchTarget::initTestCase()
     m_engine = new SemanticRuleEngine(this);
     const QString dir = sourceRulesDir();
     const QStringList ruleFiles = QDir(dir).entryList(
-            {"*.json"}, QDir::Files, QDir::Name);
+            { "*.json" }, QDir::Files, QDir::Name);
     for (const QString &filename : ruleFiles) {
         QString path = dir + "/" + filename;
         if (!m_engine->loadRuleFile(path)) {
@@ -991,6 +1048,182 @@ void tst_SearchTarget::unconsumedTextStaysAll()
     QVERIFY(!intent.keywords.isEmpty());
 }
 
+// ===== tst_LocationExtraction =====
+
+class tst_LocationExtraction : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    // Static method tests — no source-tree rule dependency
+    void expandGlobNoMatch();
+    void expandGlobSingleMatch();
+    void expandGlobMultipleMatches();
+    void expandGlobNestedDirs();
+    void expandNonGlob();
+    void expandGlobQuestionMark();
+
+    // Integration tests — inline rules only
+    void extractWechatTriggerWords();
+    void extractCustomPathResolved();
+};
+
+void tst_LocationExtraction::expandGlobNoMatch()
+{
+    // Glob matching nothing → empty result (no crash)
+    QStringList result = LocationExtractor::expandCustomPath("/tmp", "nonexistent/*/data");
+    QVERIFY(result.isEmpty());
+}
+
+void tst_LocationExtraction::expandGlobSingleMatch()
+{
+    QString tmpBase = QDir::temp().filePath("tst_loc_" + QString::number(QDateTime::currentSecsSinceEpoch()));
+    QDir().mkpath(tmpBase + "/user_a/sub/folder");
+
+    QStringList result = LocationExtractor::expandCustomPath(tmpBase, "user_*/sub/folder");
+    QCOMPARE(result.size(), 1);
+    QVERIFY(result.first().endsWith("/user_a/sub/folder"));
+
+    QDir(tmpBase).removeRecursively();
+}
+
+void tst_LocationExtraction::expandGlobMultipleMatches()
+{
+    QString tmpBase = QDir::temp().filePath("tst_loc_" + QString::number(QDateTime::currentSecsSinceEpoch()));
+    QDir().mkpath(tmpBase + "/wxid_abc/msg/file");
+    QDir().mkpath(tmpBase + "/wxid_def/msg/file");
+    QDir().mkpath(tmpBase + "/wxid_ghi/msg/file");
+
+    QStringList result = LocationExtractor::expandCustomPath(tmpBase, "wxid_*/msg/file");
+    // At least our 3 test dirs should be present
+    QVERIFY(result.size() >= 3);
+    bool hasA = false, hasD = false, hasG = false;
+    for (const QString &p : result) {
+        if (p.contains("/wxid_abc/msg/file")) hasA = true;
+        if (p.contains("/wxid_def/msg/file")) hasD = true;
+        if (p.contains("/wxid_ghi/msg/file")) hasG = true;
+    }
+    QVERIFY(hasA && hasD && hasG);
+
+    QDir(tmpBase).removeRecursively();
+}
+
+void tst_LocationExtraction::expandGlobNestedDirs()
+{
+    // Pattern: a/b/*/c/d → a/<user>/c/d
+    QString tmpBase = QDir::temp().filePath("tst_loc_" + QString::number(QDateTime::currentMSecsSinceEpoch()));
+    QDir().mkpath(tmpBase + "/docs/users/u1/c/d");
+    QDir().mkpath(tmpBase + "/docs/users/u2/c/d");
+
+    QStringList result = LocationExtractor::expandCustomPath(tmpBase, "docs/users/*/c/d");
+    QVERIFY(result.size() >= 2);
+
+    QDir(tmpBase).removeRecursively();
+}
+
+void tst_LocationExtraction::expandNonGlob()
+{
+    // Non-glob path is returned as-is, appended to base
+    QStringList result = LocationExtractor::expandCustomPath("/home/test", "Downloads/myapp/data");
+    QCOMPARE(result, QStringList { "/home/test/Downloads/myapp/data" });
+}
+
+void tst_LocationExtraction::expandGlobQuestionMark()
+{
+    // ? matches single character
+    QString tmpBase = QDir::temp().filePath("tst_loc_" + QString::number(QDateTime::currentMSecsSinceEpoch()));
+    QDir().mkpath(tmpBase + "/dir_a/data");
+    QDir().mkpath(tmpBase + "/dir_b/data");
+    QDir().mkpath(tmpBase + "/dir_abc/data");   // won't match "?_" pattern
+
+    QStringList result = LocationExtractor::expandCustomPath(tmpBase, "dir_?/data");
+    QVERIFY(result.size() >= 2);
+
+    bool hasA = false, hasB = false;
+    for (const QString &p : result) {
+        if (p.endsWith("/dir_a/data")) hasA = true;
+        if (p.endsWith("/dir_b/data")) hasB = true;
+    }
+    QVERIFY(hasA && hasB);
+
+    QDir(tmpBase).removeRecursively();
+}
+
+void tst_LocationExtraction::extractWechatTriggerWords()
+{
+    // Build inline rule engine to avoid source-tree / local filesystem dependency.
+    // Directory must be under QDir::homePath() so expandCustomPath can find it.
+    const QString suffix = QString::number(QDateTime::currentSecsSinceEpoch());
+    const QString baseName = "tst_wechat_" + suffix;
+    const QString tmpDir = QDir::home().filePath(baseName);
+    QDir().mkpath(tmpDir);
+
+    QByteArray json = makeRuleJson("location", "loc_test_wechat", "微信|vx|wechat", 180,
+                                   { { "custom_path", baseName },
+                                     { "include_hidden", false } });
+
+    QFile f(QDir::temp().filePath("tst_wechat_inline.json"));
+    QVERIFY(f.open(QIODevice::WriteOnly));
+    f.write(json);
+    f.close();
+
+    SemanticRuleEngine engine;
+    QVERIFY(engine.loadRuleFile(f.fileName()));
+
+    LocationExtractor extractor(&engine);
+    const QStringList inputs = { "微信的文件", "vx收到的", "wechat文件" };
+    for (const QString &input : inputs) {
+        ParsedIntent intent;
+        extractor.extract(input, intent);
+        QVERIFY2(!intent.consumedSpans.isEmpty(),
+                 qUtf8Printable("Expected consumed span for: " + input));
+        QVERIFY2(!intent.searchDirectories.isEmpty(),
+                 qUtf8Printable("Expected searchDirectory for: " + input));
+    }
+
+    f.remove();
+    QDir(tmpDir).rmdir(tmpDir);
+}
+
+void tst_LocationExtraction::extractCustomPathResolved()
+{
+    // Verify extract() resolves custom_path and appends to searchDirectories.
+    // Directory must live under QDir::homePath() so expandCustomPath can find it.
+    const QString suffix = QString::number(QDateTime::currentSecsSinceEpoch());
+    const QString baseName = "tst_custom_" + suffix;
+    // Create under home, not QDir::temp() (which may be /tmp, outside home path)
+    const QString tmpDir = QDir::home().filePath(baseName);
+    QDir().mkpath(tmpDir + "/data");
+
+    QByteArray json = makeRuleJson("location", "loc_test_cp", "我的目录", 180,
+                                   { { "custom_path", baseName + "/data" },
+                                     { "include_hidden", false } });
+
+    QFile f(QDir::temp().filePath("tst_cp_inline.json"));
+    QVERIFY(f.open(QIODevice::WriteOnly));
+    f.write(json);
+    f.close();
+
+    SemanticRuleEngine engine;
+    QVERIFY(engine.loadRuleFile(f.fileName()));
+
+    LocationExtractor extractor(&engine);
+    ParsedIntent intent;
+    extractor.extract("我的目录的文件", intent);
+
+    QVERIFY2(!intent.searchDirectories.isEmpty(),
+             "Expected at least one resolved search directory");
+    // Path must end with /data
+    bool hasData = false;
+    for (const QString &path : intent.searchDirectories) {
+        if (path.endsWith("/data")) hasData = true;
+    }
+    QVERIFY(hasData);
+
+    f.remove();
+    QDir(tmpDir).removeRecursively();
+}
+
 // ===== tst_SemanticQueryBuilderTarget =====
 
 class tst_SemanticQueryBuilderTarget : public QObject
@@ -1018,7 +1251,7 @@ ParsedIntent tst_SemanticQueryBuilderTarget::makeIntent(
 void tst_SemanticQueryBuilderTarget::defaultTarget()
 {
     SemanticQueryBuilder builder;
-    ParsedIntent intent = makeIntent({"测试"}, SearchTarget::All);
+    ParsedIntent intent = makeIntent({ "测试" }, SearchTarget::All);
     SemanticSearchPlan plan = builder.build(intent);
 
     // All three paths should produce queries
@@ -1030,7 +1263,7 @@ void tst_SemanticQueryBuilderTarget::defaultTarget()
 void tst_SemanticQueryBuilderTarget::fileNameOnlyTarget()
 {
     SemanticQueryBuilder builder;
-    ParsedIntent intent = makeIntent({"测试"}, SearchTarget::FileNameOnly);
+    ParsedIntent intent = makeIntent({ "测试" }, SearchTarget::FileNameOnly);
     SemanticSearchPlan plan = builder.build(intent);
 
     // Only filename query should be built
@@ -1042,7 +1275,7 @@ void tst_SemanticQueryBuilderTarget::fileNameOnlyTarget()
 void tst_SemanticQueryBuilderTarget::contentOnlyTarget()
 {
     SemanticQueryBuilder builder;
-    ParsedIntent intent = makeIntent({"测试"}, SearchTarget::ContentOnly);
+    ParsedIntent intent = makeIntent({ "测试" }, SearchTarget::ContentOnly);
     SemanticSearchPlan plan = builder.build(intent);
 
     // Filename should NOT be built; content and ocr should
@@ -1053,13 +1286,41 @@ void tst_SemanticQueryBuilderTarget::contentOnlyTarget()
 
 // ===== Factory functions =====
 
-QObject *create_tst_RuleEngine() { return new tst_RuleEngine(); }
-QObject *create_tst_TimeExtraction() { return new tst_TimeExtraction(); }
-QObject *create_tst_FileTypeExtraction() { return new tst_FileTypeExtraction(); }
-QObject *create_tst_KeywordExtraction() { return new tst_KeywordExtraction(); }
-QObject *create_tst_ParsedIntent() { return new tst_ParsedIntent(); }
-QObject *create_tst_IsSemanticQuery() { return new tst_IsSemanticQuery(); }
-QObject *create_tst_SearchTarget() { return new tst_SearchTarget(); }
-QObject *create_tst_SemanticQueryBuilderTarget() { return new tst_SemanticQueryBuilderTarget(); }
+QObject *create_tst_RuleEngine()
+{
+    return new tst_RuleEngine();
+}
+QObject *create_tst_TimeExtraction()
+{
+    return new tst_TimeExtraction();
+}
+QObject *create_tst_FileTypeExtraction()
+{
+    return new tst_FileTypeExtraction();
+}
+QObject *create_tst_KeywordExtraction()
+{
+    return new tst_KeywordExtraction();
+}
+QObject *create_tst_ParsedIntent()
+{
+    return new tst_ParsedIntent();
+}
+QObject *create_tst_IsSemanticQuery()
+{
+    return new tst_IsSemanticQuery();
+}
+QObject *create_tst_SearchTarget()
+{
+    return new tst_SearchTarget();
+}
+QObject *create_tst_SemanticQueryBuilderTarget()
+{
+    return new tst_SemanticQueryBuilderTarget();
+}
+QObject *create_tst_LocationExtraction()
+{
+    return new tst_LocationExtraction();
+}
 
 #include "tst_semantic_search.moc"

--- a/src/dfm-search/dfm-search-lib/semantic/extractors/locationextractor.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/extractors/locationextractor.cpp
@@ -7,6 +7,7 @@
 #include "semantic/semanticruleengine.h"
 
 #include <QDir>
+#include <QFileInfo>
 #include <QStandardPaths>
 
 DFM_SEARCH_BEGIN_NS
@@ -33,15 +34,29 @@ void LocationExtractor::extract(const QString &input, ParsedIntent &intent)
         const QVariantMap metadata = m_engine->ruleMetadata("location", ruleIds[i]);
 
         const QString xdgType = metadata.value("xdg_type").toString();
+        const QString customSubdir = metadata.value("custom_path").toString();
         const bool includeHidden = metadata.value("include_hidden", false).toBool();
 
-        const QString path = resolveXdgPath(xdgType);
-        if (path.isEmpty()) {
+        QStringList resolvedPaths;
+        if (!customSubdir.isEmpty()) {
+            resolvedPaths = expandCustomPath(QDir::homePath(), customSubdir);
+        } else {
+            const QString path = resolveXdgPath(xdgType);
+            if (!path.isEmpty()) {
+                resolvedPaths = { path };
+            }
+        }
+        if (resolvedPaths.isEmpty()) {
             continue;
         }
 
-        if (!intent.searchDirectories.contains(path)) {
-            intent.searchDirectories.append(path);
+        for (const QString &path : resolvedPaths) {
+            if (!QFileInfo::exists(path)) {
+                continue;
+            }
+            if (!intent.searchDirectories.contains(path)) {
+                intent.searchDirectories.append(path);
+            }
         }
 
         if (includeHidden) {
@@ -54,6 +69,59 @@ void LocationExtractor::extract(const QString &input, ParsedIntent &intent)
         span.ruleId = ruleIds[i];
         intent.consumedSpans.append(span);
     }
+}
+
+QStringList LocationExtractor::expandCustomPath(const QString &basePath, const QString &relPath)
+{
+    // Reject path traversal segments to prevent escaping basePath
+    const QStringList segments = relPath.split(QLatin1String("/"), Qt::SkipEmptyParts);
+    if (segments.contains(QLatin1String("..")) || segments.contains(QLatin1String("."))) {
+        qWarning() << "Path traversal rejected in custom_path:" << relPath;
+        return {};
+    }
+
+    const QString normalizedBase = QDir::cleanPath(basePath);
+    QStringList candidates = { normalizedBase };
+
+    for (const QString &seg : segments) {
+        const bool isGlob = seg.contains(QLatin1Char('*')) || seg.contains(QLatin1Char('?'));
+        if (isGlob) {
+            QStringList next;
+            for (const QString &base : candidates) {
+                QDir dir(base);
+                const QStringList matches = dir.entryList(
+                        QStringList { seg },
+                        QDir::Dirs | QDir::NoDotAndDotDot,
+                        QDir::Name);
+                for (const QString &match : matches) {
+                    next.append(base + QLatin1String("/") + match);
+                }
+            }
+            candidates = next;
+        } else {
+            for (QString &c : candidates) {
+                c += QLatin1String("/") + seg;
+            }
+        }
+    }
+
+    // Final guard: verify all results stay within basePath
+    const QStringList valid = [&]() {
+        QStringList result;
+        for (const QString &p : candidates) {
+            const QString cleaned = QDir::cleanPath(p);
+            if (cleaned.startsWith(normalizedBase + QLatin1String("/"))
+                    || cleaned == normalizedBase) {
+                result.append(cleaned);
+            } else {
+                qWarning() << "Path escaped basePath:" << cleaned
+                           << "base:" << normalizedBase;
+            }
+        }
+        return result;
+    }();
+
+    return valid;
 }
 
 QString LocationExtractor::resolveXdgPath(const QString &xdgType)

--- a/src/dfm-search/dfm-search-lib/semantic/extractors/locationextractor.h
+++ b/src/dfm-search/dfm-search-lib/semantic/extractors/locationextractor.h
@@ -25,8 +25,22 @@ public:
      * @param xdgType One of: "desktop", "download", "documents", "pictures",
      *                "music", "movies", "trash"
      * @return The resolved absolute path, or empty string if unknown
+     *
+     * @note For non-XDG paths (e.g., WeChat), use metadata "custom_path"
+     *       instead, which resolves to ~/<custom_path>.
      */
     static QString resolveXdgPath(const QString &xdgType);
+
+    /**
+     * @brief Expand a custom_path (may contain glob wildcards) to concrete absolute paths.
+     * @param basePath The base directory (e.g., home path)
+     * @param relPath  The relative path, may contain * or ? wildcards
+     * @return List of absolute paths. Empty if glob matches nothing.
+     *
+     * Walk relPath segment-by-segment: non-glob segments are appended directly,
+     * glob segments are expanded by enumerating the parent directory.
+     */
+    static QStringList expandCustomPath(const QString &basePath, const QString &relPath);
 
 private:
     SemanticRuleEngine *m_engine;

--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/location_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/location_rules.json
@@ -73,25 +73,14 @@
                     }
                 },
                 {
-                    "id": "loc_trash",
-                    "pattern": "回收站|垃圾箱",
-                    "description": "Trash directory",
+                    "id": "loc_wechat_data",
+                    "pattern": "微信发给我的|微信发我的|微信接收的|微信群里的|微信群里|微信里|微信|vx|wechat",
+                    "description": "WeChat received files directory — longer patterns first for maximal span consumption",
                     "enabled": true,
-                    "priority": 200,
+                    "priority": 180,
                     "metadata": {
-                        "xdg_type": "trash",
-                        "include_hidden": true
-                    }
-                },
-                {
-                    "id": "loc_deleted",
-                    "pattern": "删除的|删除掉的",
-                    "description": "Deleted files (maps to trash)",
-                    "enabled": true,
-                    "priority": 200,
-                    "metadata": {
-                        "xdg_type": "trash",
-                        "include_hidden": true
+                        "custom_path": "Documents/xwechat_files/*/msg/file",
+                        "include_hidden": false
                     }
                 }
             ]


### PR DESCRIPTION
1. Removed trash/recycle bin related tests and rules from Chinese NLP as
the functionality was deprecated
2. Added support for WeChat file location extraction with glob pattern
matching
3. Implemented LocationExtractor with custom path resolution and glob
expansion
4. Added comprehensive tests for location extraction and glob path
handling
5. Reorganized file extension lists in tests for better readability
6. Added cleanup handling for test directories

Influence:
1. Verify Chinese semantic search queries no longer support trash
location
2. Test WeChat file path extraction with various patterns
3. Verify custom path expansion with glob patterns works correctly
4. Check regular XDG directory resolution still functions
5. Ensure file type and extension matching remains accurate

refactor: 更新语义搜索规则和测试

1. 从中文自然语言处理中移除了回收站/垃圾箱相关测试和规则，因功能已弃用
2. 新增对微信文件路径的提取支持，包含通配符模式匹配
3. 实现LocationExtractor，支持自定义路径解析和通配符展开
4. 添加全面的位置提取和通配符路径处理测试
5. 重组测试中的文件扩展名列表以提高可读性
6. 添加测试目录的清理处理

影响范围:
1. 验证中文语义搜索不再支持回收站位置
2. 测试使用各种模式的微信文件路径提取
3. 确保带通配符的自定义路径展开正常工作
4. 检查普通的XDG目录解析功能仍正常
5. 确认文件类型和扩展名匹配仍准确

## Summary by Sourcery

Deprecate trash-bin location handling in Chinese semantic search while introducing flexible location extraction for WeChat and other custom paths.

New Features:
- Add support for resolving custom semantic search locations via LocationExtractor using custom_path metadata and glob pattern expansion.
- Introduce WeChat-related location intents in Chinese semantic search queries to map to user document directories.

Enhancements:
- Refine semantic search location extraction to handle multiple resolved directories and avoid duplicates, including hidden-file handling via metadata.
- Reorganize and normalize file type extension lists and related tests for improved readability and consistency in Chinese NLP and file type extraction tests.
- Add explicit test coverage for glob-based path expansion and inline location rules without depending on source-tree rule files, plus cleanup of temporary test directories.

Tests:
- Remove trash and deleted-location tests from Chinese NLP and semantic query suites in line with deprecated trash search support.
- Add a dedicated tst_LocationExtraction test suite and wire it into the autotest main runner to validate location and glob expansion behavior.
- Extend semantic query tests to cover WeChat location queries and ensure temporary directories used by location tests are created and cleaned up.