### PR TITLE
fix: add isMountedByGio to check GVfs mount status

### DIFF
--- a/src/dfm-mount/private/dnetworkmounter.cpp
+++ b/src/dfm-mount/private/dnetworkmounter.cpp
@@ -323,7 +323,7 @@ void DNetworkMounter::mountByDaemon(const QString &address, GetMountPassInfo get
 
     QString mpt;
     QString addr(QUrl::fromPercentEncoding(address.toLower().toLocal8Bit()));
-    if (isMounted(addr, mpt)) {
+    if (isMounted(addr, mpt) || isMountedByGio(address.toLower(), mpt)) {
         if (mountResult)
             mountResult(false, Utils::genOperateErrorInfo(DeviceError::kGIOErrorAlreadyMounted), mpt);
         return;
@@ -690,4 +690,40 @@ bool DNetworkMounter::isMounted(const QString &address, QString &mpt)
     } else {
         return false;
     }
+}
+
+bool DNetworkMounter::isMountedByGio(const QString &url, QString &mpt)
+{
+    GFile_autoptr file = g_file_new_for_uri(url.toStdString().c_str());
+    if (!file)
+        return false;
+
+    GError_autoptr error = nullptr;
+    GMount_autoptr mount = g_file_find_enclosing_mount(file, nullptr, &error);
+    if (!mount) {
+        qWarning() << "gio: cannot find enclosing mount for" << url << (error ? error->message : "");
+        return false;
+    }
+
+    // Prefer the default location (e.g., the mount's "home" directory)
+    GFile_autoptr defLocation = g_mount_get_default_location(mount);
+    if (defLocation) {
+        g_autofree char *path = g_file_get_path(defLocation);
+        if (path) {
+            mpt = QString::fromUtf8(path);
+            return true;
+        }
+    }
+
+    // Fallback to the mount root
+    GFile_autoptr root = g_mount_get_root(mount);
+    if (root) {
+        g_autofree char *path = g_file_get_path(root);
+        if (path) {
+            mpt = QString::fromUtf8(path);
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/dfm-mount/private/dnetworkmounter.h
+++ b/src/dfm-mount/private/dnetworkmounter.h
@@ -51,6 +51,7 @@ private:
     static void doLastMount(const QString &address, const MountPassInfo info, DeviceOperateCallbackWithMessage cb);
 
     static bool isMounted(const QString &address, QString &mpt);
+    static bool isMountedByGio(const QString &url, QString &mpt);
 };
 
 DFM_MOUNT_END_NS


### PR DESCRIPTION
Add DNetworkMounter::isMountedByGio which uses GIO API to query whether a network URL is mounted via GVfs, returning the mount point. Also integrate the check in mountByDaemon to avoid duplicate mounting.

添加 isMountedByGio 函数，通过 GIO API 检查 GVfs 挂载状态，
并在 mountByDaemon 中集成该检查，避免重复挂载。

Log: 新增 isMountedByGio 函数检查 GVfs 挂载状态
Bug: https://pms.uniontech.com/bug-view-367163.html
Influence: 挂载网络设备时增加 GVfs 挂载检测，避免因 GVfs 已挂载导致重复挂载失败。