### PR TITLE
feat: add file extension filter support for searches

### DIFF
--- a/autotests/dfm-search-tests/tst_chinese_nlp.cpp
+++ b/autotests/dfm-search-tests/tst_chinese_nlp.cpp
@@ -49,7 +49,7 @@ QStringList videoExpectedExts()
         "hdmov", "ifo", "ivf", "m1v", "m2p", "m2t", "m2ts", "m2v", "m4b", "m4p", "m4v", "mkv",
         "mp2v", "mp4", "mp4v", "mpe", "mpeg", "mpg", "mpls", "mpv2", "mpv4", "mov", "mts", "ogm",
         "ogv", "pss", "pva", "qt", "ram", "ratdvd", "rm", "rmm", "rmvb", "roq", "rpm", "smil", "smk",
-        "swf", "tp", "tpr", "ts", "vob", "vp6", "webm", "wm", "wmp", "wmv"
+        "swf", "tp", "tpr", "vob", "vp6", "webm", "wm", "wmp", "wmv"
     };
 }
 

--- a/autotests/dfm-search-tests/tst_content_retriever.cpp
+++ b/autotests/dfm-search-tests/tst_content_retriever.cpp
@@ -88,6 +88,8 @@ private Q_SLOTS:
     void fetchContent_single();
     void fetchContent_batch();
     void fetchHighlight_usesTemporaryIndex();
+    void fetchContent_semanticRoutingFailsWhenNoDConfig();
+    void fetchHighlight_semanticRoutingFailsWhenNoDConfig();
     void concurrentFetch_sharedRetriever();
 };
 
@@ -150,6 +152,22 @@ void tst_ContentRetriever::fetchHighlight_usesTemporaryIndex()
                                                      SearchType::Content,
                                                      options);
     QVERIFY(snippet.contains("budget", Qt::CaseInsensitive));
+}
+
+void tst_ContentRetriever::fetchContent_semanticRoutingFailsWhenNoDConfig()
+{
+    // In test environment dconfig is unavailable, so semanticDocExtensions()/semanticPicExtensions()
+    // return empty sets → Semantic type should be rejected with a warning and return empty.
+    ContentRetriever retriever;
+    QVERIFY(retriever.fetchContent("/tmp/doc-a.txt", SearchType::Semantic).isEmpty());
+    QVERIFY(retriever.fetchContent("/tmp/img-a.png", SearchType::Semantic).isEmpty());
+}
+
+void tst_ContentRetriever::fetchHighlight_semanticRoutingFailsWhenNoDConfig()
+{
+    ContentRetriever retriever;
+    HighlightOptions options;
+    QVERIFY(retriever.fetchHighlight("/tmp/doc-b.txt", "budget", SearchType::Semantic, options).isEmpty());
 }
 
 void tst_ContentRetriever::concurrentFetch_sharedRetriever()

--- a/autotests/dfm-search-tests/tst_semantic_search.cpp
+++ b/autotests/dfm-search-tests/tst_semantic_search.cpp
@@ -713,7 +713,8 @@ bool checkIsSemanticQuery(SemanticRuleEngine *engine, IntentParser *parser,
             || !intent.fileExtensions.isEmpty()
             || !intent.searchDirectories.isEmpty()
             || intent.includeHidden
-            || intent.hiddenOnly;
+            || intent.hiddenOnly
+            || !intent.consumedSpans.isEmpty();
 }
 
 }   // namespace

--- a/include/dfm-search/dfm-search/field_names.h
+++ b/include/dfm-search/dfm-search/field_names.h
@@ -31,6 +31,7 @@ constexpr const wchar_t kAncestorPaths[] = L"ancestor_paths";
 // Content index field names
 namespace Content {
 constexpr const wchar_t kContents[] = L"contents";
+constexpr const wchar_t kFileExt[] = L"file_ext";
 constexpr const wchar_t kFilename[] = L"filename";
 constexpr const wchar_t kPath[] = L"path";
 constexpr const wchar_t kIsHidden[] = L"is_hidden";
@@ -44,6 +45,7 @@ constexpr const wchar_t kCheckSum[] = L"checksum";
 // OCR text index field names
 namespace OcrText {
 constexpr const wchar_t kOcrContents[] = L"ocr_contents";
+constexpr const wchar_t kFileExt[] = L"file_ext";
 constexpr const wchar_t kFilename[] = L"filename";
 constexpr const wchar_t kPath[] = L"path";
 constexpr const wchar_t kIsHidden[] = L"is_hidden";

--- a/include/dfm-search/dfm-search/textsearchapi.h
+++ b/include/dfm-search/dfm-search/textsearchapi.h
@@ -75,6 +75,24 @@ public:
      */
     bool isFullTextRetrievalEnabled() const;
 
+    // ==================== File Extension Filter ====================
+
+    /**
+     * @brief Sets file extensions to filter search results.
+     *
+     * When set, only files matching the specified extensions will be returned.
+     * Extensions should be provided without the leading dot (e.g., "jpg", "png").
+     *
+     * @param extensions The list of file extensions to filter by.
+     */
+    void setFileExtensions(const QStringList &extensions);
+
+    /**
+     * @brief Gets the file extensions used to filter search results.
+     * @return The list of file extensions, or empty list if not set.
+     */
+    QStringList fileExtensions() const;
+
     // ==================== Filename Search ====================
 
     /**

--- a/src/dfm-search/dfm-search-lib/contentsearch/contentstrategies/indexedstrategy.cpp
+++ b/src/dfm-search/dfm-search-lib/contentsearch/contentstrategies/indexedstrategy.cpp
@@ -4,7 +4,6 @@
 #include "indexedstrategy.h"
 
 #include <QDir>
-#include <QFileInfo>
 #include <QMimeDatabase>
 #include <QTextStream>
 #include <QThread>
@@ -219,6 +218,27 @@ Lucene::QueryPtr ContentIndexedStrategy::buildLuceneQuery(const SearchQuery &que
             }
         }
 
+        // Add file extension filter query (pushed down to index query layer)
+        {
+            const QStringList fileExtensions = optAPI.fileExtensions();
+            if (!fileExtensions.isEmpty() && mainQuery) {
+                Lucene::BooleanQueryPtr extQuery = newLucene<BooleanQuery>();
+                for (const QString &ext : fileExtensions) {
+                    extQuery->add(
+                            Lucene::newLucene<Lucene::TermQuery>(
+                                    Lucene::newLucene<Lucene::Term>(
+                                            LuceneFieldNames::Content::kFileExt,
+                                            ext.toStdWString())),
+                            Lucene::BooleanClause::SHOULD);
+                }
+                extQuery->setMinimumNumberShouldMatch(1);
+                BooleanQueryPtr finalQuery = newLucene<BooleanQuery>();
+                finalQuery->add(mainQuery, BooleanClause::MUST);
+                finalQuery->add(extQuery, BooleanClause::MUST);
+                mainQuery = finalQuery;
+            }
+        }
+
         return mainQuery;
 
     } catch (const Lucene::LuceneException &e) {
@@ -328,10 +348,6 @@ void ContentIndexedStrategy::processSearchResults(const Lucene::IndexSearcherPtr
     bool enableRetrieval = optAPI.isFullTextRetrievalEnabled();
     bool detailedResults = m_options.detailedResultsEnabled();
 
-    // File extension filter (post-query filtering)
-    const QStringList fileExtensions = optAPI.fileExtensions();
-    const bool hasExtFilter = !fileExtensions.isEmpty();
-
     // Build field selector to avoid loading the large 'contents' field when not needed.
     // The contents field stores full document text and loading it for every result
     // (even when only path is needed) causes significant disk I/O overhead.
@@ -385,15 +401,6 @@ void ContentIndexedStrategy::processSearchResults(const Lucene::IndexSearcherPtr
             if (pathField.empty()) {
                 qWarning() << "Document missing path field at index:" << scoreDoc->doc;
                 continue;
-            }
-
-            // File extension filter (post-query filtering, since filename field is NGram-analyzed)
-            if (hasExtFilter) {
-                QString filePath = QString::fromStdWString(pathField);
-                QFileInfo fi(filePath);
-                if (!fileExtensions.contains(fi.suffix().toLower())) {
-                    continue;
-                }
             }
 
             SearchResult result(QString::fromStdWString(pathField));

--- a/src/dfm-search/dfm-search-lib/contentsearch/contentstrategies/indexedstrategy.cpp
+++ b/src/dfm-search/dfm-search-lib/contentsearch/contentstrategies/indexedstrategy.cpp
@@ -328,6 +328,10 @@ void ContentIndexedStrategy::processSearchResults(const Lucene::IndexSearcherPtr
     bool enableRetrieval = optAPI.isFullTextRetrievalEnabled();
     bool detailedResults = m_options.detailedResultsEnabled();
 
+    // File extension filter (post-query filtering)
+    const QStringList fileExtensions = optAPI.fileExtensions();
+    const bool hasExtFilter = !fileExtensions.isEmpty();
+
     // Build field selector to avoid loading the large 'contents' field when not needed.
     // The contents field stores full document text and loading it for every result
     // (even when only path is needed) causes significant disk I/O overhead.
@@ -381,6 +385,15 @@ void ContentIndexedStrategy::processSearchResults(const Lucene::IndexSearcherPtr
             if (pathField.empty()) {
                 qWarning() << "Document missing path field at index:" << scoreDoc->doc;
                 continue;
+            }
+
+            // File extension filter (post-query filtering, since filename field is NGram-analyzed)
+            if (hasExtFilter) {
+                QString filePath = QString::fromStdWString(pathField);
+                QFileInfo fi(filePath);
+                if (!fileExtensions.contains(fi.suffix().toLower())) {
+                    continue;
+                }
             }
 
             SearchResult result(QString::fromStdWString(pathField));

--- a/src/dfm-search/dfm-search-lib/ocrtextsearch/ocrtextstrategies/indexedstrategy.cpp
+++ b/src/dfm-search/dfm-search-lib/ocrtextsearch/ocrtextstrategies/indexedstrategy.cpp
@@ -324,6 +324,10 @@ void OcrTextIndexedStrategy::processSearchResults(const Lucene::IndexSearcherPtr
     bool enableRetrieval = optAPI.isFullTextRetrievalEnabled();
     bool detailedResults = m_options.detailedResultsEnabled();
 
+    // File extension filter (post-query filtering)
+    const QStringList fileExtensions = optAPI.fileExtensions();
+    const bool hasExtFilter = !fileExtensions.isEmpty();
+
     // Build field selector to avoid loading the large 'ocr_contents' field when not needed.
     // The ocr_contents field stores OCR-recognized text and loading it for every result
     // (even when only path is needed) causes significant disk I/O overhead.
@@ -378,6 +382,15 @@ void OcrTextIndexedStrategy::processSearchResults(const Lucene::IndexSearcherPtr
             if (pathField.empty()) {
                 qWarning() << "Document missing path field at index:" << scoreDoc->doc;
                 continue;
+            }
+
+            // File extension filter (post-query filtering, since filename field is NGram-analyzed)
+            if (hasExtFilter) {
+                QString filePath = QString::fromStdWString(pathField);
+                QFileInfo fi(filePath);
+                if (!fileExtensions.contains(fi.suffix().toLower())) {
+                    continue;
+                }
             }
 
             SearchResult result(QString::fromStdWString(pathField));

--- a/src/dfm-search/dfm-search-lib/ocrtextsearch/ocrtextstrategies/indexedstrategy.cpp
+++ b/src/dfm-search/dfm-search-lib/ocrtextsearch/ocrtextstrategies/indexedstrategy.cpp
@@ -4,7 +4,6 @@
 #include "indexedstrategy.h"
 
 #include <QDir>
-#include <QFileInfo>
 #include <QThread>
 #include <QElapsedTimer>
 
@@ -216,6 +215,27 @@ Lucene::QueryPtr OcrTextIndexedStrategy::buildLuceneQuery(const SearchQuery &que
             }
         }
 
+        // Add file extension filter query (pushed down to index query layer)
+        {
+            const QStringList fileExtensions = optAPI.fileExtensions();
+            if (!fileExtensions.isEmpty() && mainQuery) {
+                Lucene::BooleanQueryPtr extQuery = newLucene<BooleanQuery>();
+                for (const QString &ext : fileExtensions) {
+                    extQuery->add(
+                            Lucene::newLucene<Lucene::TermQuery>(
+                                    Lucene::newLucene<Lucene::Term>(
+                                            LuceneFieldNames::OcrText::kFileExt,
+                                            ext.toStdWString())),
+                            Lucene::BooleanClause::SHOULD);
+                }
+                extQuery->setMinimumNumberShouldMatch(1);
+                BooleanQueryPtr finalQuery = newLucene<BooleanQuery>();
+                finalQuery->add(mainQuery, BooleanClause::MUST);
+                finalQuery->add(extQuery, BooleanClause::MUST);
+                mainQuery = finalQuery;
+            }
+        }
+
         return mainQuery;
 
     } catch (const Lucene::LuceneException &e) {
@@ -324,10 +344,6 @@ void OcrTextIndexedStrategy::processSearchResults(const Lucene::IndexSearcherPtr
     bool enableRetrieval = optAPI.isFullTextRetrievalEnabled();
     bool detailedResults = m_options.detailedResultsEnabled();
 
-    // File extension filter (post-query filtering)
-    const QStringList fileExtensions = optAPI.fileExtensions();
-    const bool hasExtFilter = !fileExtensions.isEmpty();
-
     // Build field selector to avoid loading the large 'ocr_contents' field when not needed.
     // The ocr_contents field stores OCR-recognized text and loading it for every result
     // (even when only path is needed) causes significant disk I/O overhead.
@@ -382,15 +398,6 @@ void OcrTextIndexedStrategy::processSearchResults(const Lucene::IndexSearcherPtr
             if (pathField.empty()) {
                 qWarning() << "Document missing path field at index:" << scoreDoc->doc;
                 continue;
-            }
-
-            // File extension filter (post-query filtering, since filename field is NGram-analyzed)
-            if (hasExtFilter) {
-                QString filePath = QString::fromStdWString(pathField);
-                QFileInfo fi(filePath);
-                if (!fileExtensions.contains(fi.suffix().toLower())) {
-                    continue;
-                }
             }
 
             SearchResult result(QString::fromStdWString(pathField));

--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/filetype_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/filetype_rules.json
@@ -101,7 +101,7 @@
                     "enabled": true,
                     "priority": 150,
                     "metadata": {
-                        "extensions": ["3g2","3gp","3gp2","3gpp","amr","amv","asf","asx","avi","bdmv","bik","d2v","divx","drc","dsa","dsm","dss","dsv","evo","f4v","flc","fli","flic","flv","hdmov","ifo","ivf","m1v","m2p","m2t","m2ts","m2v","m4b","m4p","m4v","mkv","mp2v","mp4","mp4v","mpe","mpeg","mpg","mpls","mpv2","mpv4","mov","mts","ogm","ogv","pss","pva","qt","ram","ratdvd","rm","rmm","rmvb","roq","rpm","smil","smk","swf","tp","tpr","ts","vob","vp6","webm","wm","wmp","wmv"],
+                        "extensions": ["3g2","3gp","3gp2","3gpp","amr","amv","asf","asx","avi","bdmv","bik","d2v","divx","drc","dsa","dsm","dss","dsv","evo","f4v","flc","fli","flic","flv","hdmov","ifo","ivf","m1v","m2p","m2t","m2ts","m2v","m4b","m4p","m4v","mkv","mp2v","mp4","mp4v","mpe","mpeg","mpg","mpls","mpv2","mpv4","mov","mts","ogm","ogv","pss","pva","qt","ram","ratdvd","rm","rmm","rmvb","roq","rpm","smil","smk","swf","tp","tpr","vob","vp6","webm","wm","wmp","wmv"],
                         "fileTypes": ["video"]
                     }
                 },

--- a/src/dfm-search/dfm-search-lib/semantic/semanticquerybuilder.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/semanticquerybuilder.cpp
@@ -105,6 +105,11 @@ SemanticSearchPlan SemanticQueryBuilder::build(const ParsedIntent &intent)
             // Enable filename-content mixed AND search
             contentApi.setFilenameContentMixedAndSearchEnabled(true);
 
+            // Pass file extension filter to content search
+            if (!intent.fileExtensions.isEmpty()) {
+                contentApi.setFileExtensions(intent.fileExtensions);
+            }
+
             if (intent.keywords.size() == 1) {
                 plan.contentQuery = SearchFactory::createQuery(intent.keywords.first());
             } else if (intent.keywords.size() > 1) {
@@ -130,6 +135,11 @@ SemanticSearchPlan SemanticQueryBuilder::build(const ParsedIntent &intent)
 
             // Enable filename-OCR content mixed AND search
             ocrApi.setFilenameOcrContentMixedAndSearchEnabled(true);
+
+            // Pass file extension filter to OCR search
+            if (!intent.fileExtensions.isEmpty()) {
+                ocrApi.setFileExtensions(intent.fileExtensions);
+            }
 
             if (intent.keywords.size() == 1) {
                 plan.ocrQuery = SearchFactory::createQuery(intent.keywords.first());

--- a/src/dfm-search/dfm-search-lib/semantic/semanticsearcher.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/semanticsearcher.cpp
@@ -291,7 +291,8 @@ bool SemanticSearcher::isSemanticQuery(const QString &input) const
             || !intent.fileExtensions.isEmpty()
             || !intent.searchDirectories.isEmpty()
             || intent.includeHidden
-            || intent.hiddenOnly;
+            || intent.hiddenOnly
+            || !intent.consumedSpans.isEmpty();
 }
 
 void SemanticSearcher::cancel()

--- a/src/dfm-search/dfm-search-lib/textsearch/textsearchapi.cpp
+++ b/src/dfm-search/dfm-search-lib/textsearch/textsearchapi.cpp
@@ -45,6 +45,16 @@ bool TextSearchOptionsAPI::isFullTextRetrievalEnabled() const
     return m_options.customOption("fullTextRetrieval").toBool();
 }
 
+void TextSearchOptionsAPI::setFileExtensions(const QStringList &extensions)
+{
+    m_options.setCustomOption("fileExtensions", extensions);
+}
+
+QStringList TextSearchOptionsAPI::fileExtensions() const
+{
+    return m_options.customOption("fileExtensions").toStringList();
+}
+
 void TextSearchOptionsAPI::setFilenameKeyword(const QString &keyword)
 {
     m_options.setCustomOption("filenameKeyword", keyword);

--- a/src/dfm-search/dfm-search-lib/utils/contentretriever.cpp
+++ b/src/dfm-search/dfm-search-lib/utils/contentretriever.cpp
@@ -7,8 +7,10 @@
 #include <dfm-search/field_names.h>
 
 #include "utils/contenthighlighter.h"
+#include "utils/searchutility.h"
 
 #include <QDebug>
+#include <QFileInfo>
 #include <QHash>
 #include <QMutex>
 #include <QMutexLocker>
@@ -21,6 +23,7 @@
 #include <lucene++/Term.h>
 #include <lucene++/TermQuery.h>
 #include <lucene++/TopDocs.h>
+#include <optional>
 
 using namespace Lucene;
 
@@ -97,6 +100,24 @@ struct CachedIndexContext
     IndexReaderPtr reader;
     SearcherPtr searcher;
 };
+
+/**
+ * @brief Route SearchType::Semantic to Content or Ocr based on file extension.
+ * @return The resolved SearchType, or std::nullopt if the extension matches neither category.
+ */
+static std::optional<SearchType> resolveSemanticType(const QString &path)
+{
+    const QString suffix = QFileInfo(path).suffix().toLower();
+    if (suffix.isEmpty())
+        return std::nullopt;
+
+    if (SearchUtility::semanticDocExtensions().contains(suffix))
+        return SearchType::Content;
+    if (SearchUtility::semanticPicExtensions().contains(suffix))
+        return SearchType::Ocr;
+
+    return std::nullopt;
+}
 
 }   // namespace
 
@@ -198,7 +219,19 @@ QString ContentRetriever::fetchHighlight(const QString &path,
                                          const HighlightOptions &options) const
 {
     if (path.isEmpty() || keyword.isEmpty()) return {};
-    if (type != SearchType::Content && type != SearchType::Ocr) return {};
+
+    // Route SearchType::Semantic to Content or Ocr based on file extension
+    if (type == SearchType::Semantic) {
+        std::optional<SearchType> resolved = resolveSemanticType(path);
+        if (!resolved) {
+            qWarning() << "ContentRetriever: cannot route Semantic type for" << path
+                       << "- extension does not match doc or pic suffixes";
+            return {};
+        }
+        type = *resolved;
+    } else if (type != SearchType::Content && type != SearchType::Ocr) {
+        return {};
+    }
 
     const QStringList keywords = splitKeywords(keyword);
     if (keywords.isEmpty()) return {};
@@ -238,23 +271,39 @@ QMap<QString, QString> ContentRetriever::fetchHighlights(const QStringList &path
 {
     QMap<QString, QString> results;
     if (paths.isEmpty() || keyword.isEmpty()) return results;
-    if (type != SearchType::Content && type != SearchType::Ocr) return results;
+
+    if (type != SearchType::Content && type != SearchType::Ocr && type != SearchType::Semantic)
+        return results;
 
     const QStringList keywords = splitKeywords(keyword);
     if (keywords.isEmpty()) return results;
 
-    const QString indexDir = indexDirectory(type);
-
     QMutexLocker locker(&d->mutex);
-    CachedIndexContext *ctx = d->ensureIndexContext(type, indexDir);
-    if (!ctx || !ctx->searcher) {
-        return results;
-    }
 
     for (const QString &path : paths) {
+        // For Semantic, route each path individually based on its extension
+        SearchType effectiveType = type;
+        if (type == SearchType::Semantic) {
+            std::optional<SearchType> resolved = resolveSemanticType(path);
+            if (!resolved) {
+                qWarning() << "ContentRetriever: cannot route Semantic type for" << path
+                           << "- extension does not match doc or pic suffixes";
+                results.insert(path, {});
+                continue;
+            }
+            effectiveType = *resolved;
+        }
+
+        const QString indexDir = indexDirectory(effectiveType);
+        CachedIndexContext *ctx = d->ensureIndexContext(effectiveType, indexDir);
+        if (!ctx || !ctx->searcher) {
+            results.insert(path, {});
+            continue;
+        }
+
         try {
-            const DocumentPtr doc = findDocumentByPath(ctx->searcher, path, type);
-            const QString content = storedContentFromDocument(doc, type);
+            const DocumentPtr doc = findDocumentByPath(ctx->searcher, path, effectiveType);
+            const QString content = storedContentFromDocument(doc, effectiveType);
             if (content.isEmpty()) {
                 results.insert(path, {});
                 continue;
@@ -279,7 +328,18 @@ QMap<QString, QString> ContentRetriever::fetchHighlights(const QStringList &path
 QString ContentRetriever::fetchContent(const QString &path, SearchType type) const
 {
     if (path.isEmpty()) return {};
-    if (type != SearchType::Content && type != SearchType::Ocr) return {};
+
+    if (type == SearchType::Semantic) {
+        std::optional<SearchType> resolved = resolveSemanticType(path);
+        if (!resolved) {
+            qWarning() << "ContentRetriever: cannot route Semantic type for" << path
+                       << "- extension does not match doc or pic suffixes";
+            return {};
+        }
+        type = *resolved;
+    } else if (type != SearchType::Content && type != SearchType::Ocr) {
+        return {};
+    }
 
     const QString indexDir = indexDirectory(type);
 
@@ -306,19 +366,34 @@ QMap<QString, QString> ContentRetriever::fetchContents(const QStringList &paths,
 {
     QMap<QString, QString> results;
     if (paths.isEmpty()) return results;
-    if (type != SearchType::Content && type != SearchType::Ocr) return results;
 
-    const QString indexDir = indexDirectory(type);
+    if (type != SearchType::Content && type != SearchType::Ocr && type != SearchType::Semantic)
+        return results;
 
     QMutexLocker locker(&d->mutex);
-    CachedIndexContext *ctx = d->ensureIndexContext(type, indexDir);
-    if (!ctx || !ctx->searcher) {
-        return results;
-    }
 
     for (const QString &path : paths) {
+        SearchType effectiveType = type;
+        if (type == SearchType::Semantic) {
+            std::optional<SearchType> resolved = resolveSemanticType(path);
+            if (!resolved) {
+                qWarning() << "ContentRetriever: cannot route Semantic type for" << path
+                           << "- extension does not match doc or pic suffixes";
+                results.insert(path, {});
+                continue;
+            }
+            effectiveType = *resolved;
+        }
+
+        const QString indexDir = indexDirectory(effectiveType);
+        CachedIndexContext *ctx = d->ensureIndexContext(effectiveType, indexDir);
+        if (!ctx || !ctx->searcher) {
+            results.insert(path, {});
+            continue;
+        }
+
         try {
-            results.insert(path, storedContentFromDocument(findDocumentByPath(ctx->searcher, path, type), type));
+            results.insert(path, storedContentFromDocument(findDocumentByPath(ctx->searcher, path, effectiveType), effectiveType));
         } catch (const LuceneException &e) {
             qWarning() << "ContentRetriever: error for" << path
                        << QString::fromStdWString(e.getError());

--- a/src/dfm-search/dfm-search-lib/utils/searchutility.cpp
+++ b/src/dfm-search/dfm-search-lib/utils/searchutility.cpp
@@ -341,6 +341,27 @@ static QStringList getResolvedIndexedDirectories()   // Renamed for clarity
     return processedPaths;
 }
 
+// --- Loader for semantic doc/pic extensions from org.deepin.anything ---
+static QSet<QString> loadSemanticExtensionsFromDConfig(const QString &keyName)
+{
+    const QString appId = "org.deepin.anything";
+    const QString schemaId = "org.deepin.anything";
+    const QString valueKey = keyName;
+
+    std::optional<QStringList> stringListOpt =
+            tryLoadStringListFromDConfigInternal(appId, schemaId, valueKey);
+    if (!stringListOpt)
+        return {};
+
+    QSet<QString> set;
+    for (const QString &ext : *stringListOpt) {
+        QString cleaned = ext.startsWith('.') ? ext.mid(1) : ext;
+        if (!cleaned.isEmpty())
+            set.insert(cleaned.toLower());
+    }
+    return set;
+}
+
 bool isPinyinSequence(const QString &input)
 {
     if (input.isEmpty())
@@ -852,6 +873,18 @@ QStringList deepinAnythingFileTypes()
 {
     static const QStringList kTypes { "app", "archive", "audio", "doc", "pic", "video", "dir", "other" };
     return kTypes;
+}
+
+QSet<QString> semanticDocExtensions()
+{
+    static const QSet<QString> kExts = DFMSEARCH::Global::loadSemanticExtensionsFromDConfig("doc_file_suffix");
+    return kExts;
+}
+
+QSet<QString> semanticPicExtensions()
+{
+    static const QSet<QString> kExts = DFMSEARCH::Global::loadSemanticExtensionsFromDConfig("pic_file_suffix");
+    return kExts;
 }
 
 }   // namespace SearchUtility

--- a/src/dfm-search/dfm-search-lib/utils/searchutility.h
+++ b/src/dfm-search/dfm-search-lib/utils/searchutility.h
@@ -6,6 +6,7 @@
 
 #include <QStringList>
 #include <QString>
+#include <QSet>
 
 // SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
@@ -33,7 +34,23 @@ QStringList extractBooleanKeywords(const SearchQuery &query);
  */
 QStringList deepinAnythingFileTypes();
 
-}   // namespace SearchUtility
-DFM_SEARCH_END_NS
+/**
+ * @brief Get document file extensions for semantic search routing
+ *
+ * Loads from dconfig `org.deepin.anything` key `doc_file_suffix`.
+ * @return Set of lowercase extensions (without leading dot), empty if dconfig unavailable
+ */
+QSet<QString> semanticDocExtensions();
 
+/**
+ * @brief Get image file extensions for semantic search routing
+ *
+ * Loads from dconfig `org.deepin.anything` key `pic_file_suffix`.
+ * @return Set of lowercase extensions (without leading dot), empty if dconfig unavailable
+ */
+QSet<QString> semanticPicExtensions();
+
+}   // namespace SearchUtility
+
+DFM_SEARCH_END_NS
 #endif   // SEARCHUTILITY_H


### PR DESCRIPTION
Added file extension filtering capability to search functionality.
1. Introduced setFileExtensions() and fileExtensions() API methods in
TextSearchOptionsAPI
2. Implemented post-search filtering in both content and OCR search
strategies
3. Modified semantic query builder to pass extension filters to
underlying searches
4. Updated video file type rules by removing ts extension
5. Added extension filtering logic after Lucene index queries but before
result processing

The change allows users to filter search results by file extensions,
improving search precision and performance by reducing unnecessary post-
processing of unwanted file types.

Log: Added file extension filter for search results

Influence:
1. Test search with various extension filters set
2. Verify empty extension list returns all results
3. Check edge cases like mixed extensions and case sensitivity
4. Test interaction with other search filters
5. Verify semantic searches properly pass extension filters

feat: 为搜索功能添加文件扩展名过滤支持

1. 在TextSearchOptionsAPI中添加setFileExtensions()和fileExtensions()方法
2. 在内容和OCR搜索策略中实现搜索后过滤功能
3. 修改语义查询构建器以将扩展名过滤传递到底层搜索
4. 更新视频文件类型规则(移除ts扩展名)
5. 在Lucene索引查询后但结果处理前添加扩展名过滤逻辑

此更改允许用户按文件扩展名过滤搜索结果，通过减少对不需要文件类型的不必要
后处理来提高搜索精度和性能。

Log: 为搜索结果添加了文件扩展名过滤功能

Influence:
1. 测试设置不同扩展名过滤器的搜索
2. 验证空扩展名列表返回所有结果
3. 检查混合扩展名和大小写敏感性边缘情况
4. 测试与其他搜索过滤器的交互
5. 验证语义搜索是否正确传递扩展名过滤器
