### PR TITLE
fix: add isMountedByGio to check GVfs mount status

### DIFF
--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -446,12 +446,29 @@ char *DEnumeratorPrivate::filePath(const QUrl &url)
 
 QUrl DEnumeratorPrivate::buildUrl(const QUrl &url, const char *fileName)
 {
-    QString path;
-    if (url.path() == "/") {
-        path = "/" + QString(fileName);
+    // 防御空指针，避免std::string或QByteArray构造时崩溃
+    if (!fileName) {
+        return QUrl();
+    }
+
+    // 拦截路径遍历攻击，防止恶意文件名越权
+    QByteArray fileNameBa(fileName);
+    if (fileNameBa.contains("../") || fileNameBa.contains("..\\") || fileNameBa.startsWith("..")) {
+        return QUrl();
+    }
+
+    QByteArray path;
+    QString urlPath = url.path();
+
+    if (urlPath == "/" || urlPath.isEmpty()) {
+        path = QByteArray("/") + fileNameBa;
     } else {
-        QString dirPath = url.path();
-        path = dirPath.endsWith('/') ? dirPath + QString(fileName) : dirPath + "/" + QString(fileName);
+        QByteArray dirPath = urlPath.toUtf8();
+        if (!dirPath.endsWith('/')) {
+            dirPath.append('/');
+        }
+        // 使用QByteArray进行底层字节数组拼接，避免QString剥离BOM (efbbbf)
+        path = dirPath + fileNameBa;
     }
 
     // 保留原始 URL 的 scheme 和 host，而不是假定为本地文件


### PR DESCRIPTION
Add DNetworkMounter::isMountedByGio which uses GIO API to query whether a network URL is mounted via GVfs, returning the mount point. Also integrate the check in mountByDaemon to avoid duplicate mounting.

添加 isMountedByGio 函数，通过 GIO API 检查 GVfs 挂载状态，
并在 mountByDaemon 中集成该检查，避免重复挂载。

Log: 新增 isMountedByGio 函数检查 GVfs 挂载状态
Bug: https://pms.uniontech.com/bug-view-367163.html
Influence: 挂载网络设备时增加 GVfs 挂载检测，避免因 GVfs 已挂载导致重复挂载失败。