### PR TITLE
fix: correct loading of string list from DConfig

### DIFF
--- a/src/dfm-search/dfm-search-lib/utils/searchutility.cpp
+++ b/src/dfm-search/dfm-search-lib/utils/searchutility.cpp
@@ -129,7 +129,7 @@ static std::optional<QStringList> tryLoadStringListFromDConfigInternal(
         return std::nullopt;   // Type mismatch
     }
     // No need to delete dconfigPtr, dconfigParent will manage it when it goes out of scope.
-    return value.toStringList();
+    return value.toString().split(';');
 }
 
 // --- Specific Loader for "supportedFileExtensions" ---


### PR DESCRIPTION
1. Changed `value.toStringList()` to `value.toString().split(';')` in
`tryLoadStringListFromDConfigInternal`.
2. The DConfig value for `supportedFileExtensions` is stored as a
semicolon-separated string, not a native QStringList.
3. Previously, `toStringList()` would fail due to type mismatch,
returning `std::nullopt` or an empty list.
4. Now the function correctly parses the string into a list, restoring
proper file extension filtering in searches.

Log: Fixed search file extension configuration loading

Influence:
1. Verify that searching with file extension filters (e.g., *.txt,
*.pdf) functions correctly.
2. Test with multiple extensions in the configuration string.
3. Test with an empty string to ensure no extensions are applied.
4. Test with invalid or malformed extension strings (e.g., missing
separators).
5. Verify that the fix does not break existing functionality when the
config is not set.

fix: 修正从 DConfig 加载字符串列表的方式

1. 将 `tryLoadStringListFromDConfigInternal` 中的 `value.toStringList()`
改为 `value.toString().split(';')`。
2. `supportedFileExtensions` 的 DConfig 值存储为分号分隔的字符串，而非原
生的 QStringList。
3. 之前使用 `toStringList()` 会因类型不匹配而返回 `std::nullopt` 或空
列表。
4. 现在函数能正确解析字符串为列表，恢复搜索中正确的文件扩展名过滤。

Log: 修复搜索文件扩展名配置加载问题

Influence:
1. 验证带文件扩展名过滤（如 *.txt, *.pdf）的搜索功能是否正常。
2. 测试配置中包含多个扩展名的情况。
3. 测试空字符串配置，确保不应用任何扩展名过滤。
4. 测试无效或格式错误的扩展名字符串（例如缺少分隔符）。
5. 验证未设置配置时原有功能不受影响。
