### PR TITLE
refactor: refactor semantic types to use PIMPL pattern

### DIFF
--- a/autotests/dfm-search-tests/tst_chinese_nlp.cpp
+++ b/autotests/dfm-search-tests/tst_chinese_nlp.cpp
@@ -288,8 +288,8 @@ void tst_ChineseNLP::timePreset_today()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("今天的文件"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
 }
 
 void tst_ChineseNLP::timePreset_today_alt()
@@ -297,21 +297,21 @@ void tst_ChineseNLP::timePreset_today_alt()
     // 今日 and 今日份
     ParsedIntent intent1;
     m_parser->parse(QStringLiteral("今日的文档"), intent1);
-    QCOMPARE(intent1.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent1.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent1.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent1.timeConstraint().preset(), TimePreset::Today);
 
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("今日份图片"), intent2);
-    QCOMPARE(intent2.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent2.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent2.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent2.timeConstraint().preset(), TimePreset::Today);
 }
 
 void tst_ChineseNLP::timePreset_yesterday()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("昨天的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Yesterday);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Yesterday);
 }
 
 void tst_ChineseNLP::timePreset_yesterday_variants()
@@ -322,8 +322,8 @@ void tst_ChineseNLP::timePreset_yesterday_variants()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
-        QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-        QCOMPARE(intent.timeConstraint().preset, TimePreset::Yesterday);
+        QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+        QCOMPARE(intent.timeConstraint().preset(), TimePreset::Yesterday);
     }
 }
 
@@ -331,8 +331,8 @@ void tst_ChineseNLP::timePreset_dayBeforeYesterday()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("前天的图片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::DayBeforeYesterday);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::DayBeforeYesterday);
 }
 
 void tst_ChineseNLP::timePreset_thisWeek_variants()
@@ -342,8 +342,8 @@ void tst_ChineseNLP::timePreset_thisWeek_variants()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
-        QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-        QCOMPARE(intent.timeConstraint().preset, TimePreset::ThisWeek);
+        QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+        QCOMPARE(intent.timeConstraint().preset(), TimePreset::ThisWeek);
     }
 }
 
@@ -354,8 +354,8 @@ void tst_ChineseNLP::timePreset_lastWeek_variants()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
-        QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-        QCOMPARE(intent.timeConstraint().preset, TimePreset::LastWeek);
+        QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+        QCOMPARE(intent.timeConstraint().preset(), TimePreset::LastWeek);
     }
 }
 
@@ -366,8 +366,8 @@ void tst_ChineseNLP::timePreset_thisMonth_variants()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
-        QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-        QCOMPARE(intent.timeConstraint().preset, TimePreset::ThisMonth);
+        QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+        QCOMPARE(intent.timeConstraint().preset(), TimePreset::ThisMonth);
     }
 }
 
@@ -377,8 +377,8 @@ void tst_ChineseNLP::timePreset_lastMonth_variants()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
-        QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-        QCOMPARE(intent.timeConstraint().preset, TimePreset::LastMonth);
+        QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+        QCOMPARE(intent.timeConstraint().preset(), TimePreset::LastMonth);
     }
 }
 
@@ -389,8 +389,8 @@ void tst_ChineseNLP::timePreset_thisYear_variants()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
-        QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-        QCOMPARE(intent.timeConstraint().preset, TimePreset::ThisYear);
+        QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+        QCOMPARE(intent.timeConstraint().preset(), TimePreset::ThisYear);
     }
 }
 
@@ -400,8 +400,8 @@ void tst_ChineseNLP::timePreset_lastYear_variants()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
-        QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-        QCOMPARE(intent.timeConstraint().preset, TimePreset::LastYear);
+        QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+        QCOMPARE(intent.timeConstraint().preset(), TimePreset::LastYear);
     }
 }
 
@@ -411,13 +411,13 @@ void tst_ChineseNLP::timeCustom_year()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("2025年的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent.timeConstraint().customStart.date().month(), 1);
-    QCOMPARE(intent.timeConstraint().customStart.date().day(), 1);
-    QCOMPARE(intent.timeConstraint().customEnd.date().year(), 2025);
-    QCOMPARE(intent.timeConstraint().customEnd.date().month(), 12);
-    QCOMPARE(intent.timeConstraint().customEnd.date().day(), 31);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent.timeConstraint().customStart().date().month(), 1);
+    QCOMPARE(intent.timeConstraint().customStart().date().day(), 1);
+    QCOMPARE(intent.timeConstraint().customEnd().date().year(), 2025);
+    QCOMPARE(intent.timeConstraint().customEnd().date().month(), 12);
+    QCOMPARE(intent.timeConstraint().customEnd().date().day(), 31);
 }
 
 void tst_ChineseNLP::timeCustom_year_twoDigit()
@@ -425,9 +425,9 @@ void tst_ChineseNLP::timeCustom_year_twoDigit()
     // Two-digit year: 25 -> 2025
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("25年的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent.timeConstraint().customEnd.date().year(), 2025);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent.timeConstraint().customEnd().date().year(), 2025);
 }
 
 // ===== File Type Tests =====
@@ -606,8 +606,8 @@ void tst_ChineseNLP::noise_action_words()
     // "搜索" is noise; "上周" is time; "图片" is filetype
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("搜索上周的图片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::LastWeek);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::LastWeek);
     // Filetype should be matched
     QVERIFY(!intent.fileExtensions().isEmpty());
     // No keywords since all text is consumed
@@ -619,8 +619,8 @@ void tst_ChineseNLP::noise_polite_words()
     // "请帮我找" consumed as noise; "今天" time; "文档" filetype
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("请帮我找今天的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
     QVERIFY(!intent.fileExtensions().isEmpty());
     // All text consumed by noise + time + filetype
     QVERIFY(intent.keywords().isEmpty());
@@ -631,8 +631,8 @@ void tst_ChineseNLP::noise_suffix_words()
     // "昨天上午" time; "的照片" noise_suffix
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("昨天上午的照片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Yesterday);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Yesterday);
     QVERIFY(!intent.fileExtensions().isEmpty());
     QVERIFY(intent.keywords().isEmpty());
 }
@@ -643,8 +643,8 @@ void tst_ChineseNLP::combined_timeAndFiletype()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("今天的图片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
     const QStringList imageExts = imageExpectedExts();
     QVERIFY(setEquals(intent.fileExtensions(), imageExts));
     // "的" is consumed by noise_suffix "的图片"
@@ -655,8 +655,8 @@ void tst_ChineseNLP::combined_timeAndFiletype_multi()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("今天的图片和视频"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
     // Should contain both image and video extensions
     QVERIFY(intent.fileExtensions().contains("jpg"));
     QVERIFY(intent.fileExtensions().contains("png"));
@@ -670,8 +670,8 @@ void tst_ChineseNLP::combined_timeAndFiletype_all()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("今天的图片和视频和音频"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
     QVERIFY(intent.fileExtensions().contains("jpg"));
     QVERIFY(intent.fileExtensions().contains("mp4"));
     QVERIFY(intent.fileExtensions().contains("mp3"));
@@ -686,8 +686,8 @@ void tst_ChineseNLP::combined_timeAndKeyword()
     // before keyword extractor and matches "文档".
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("今天包含会议记录的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
     QVERIFY(intent.keywords().contains("会议记录"));
     // "文档" matches filetype_document_general
     QVERIFY(!intent.fileExtensions().isEmpty());
@@ -711,8 +711,8 @@ void tst_ChineseNLP::combined_timeAndFiletypeAndKeyword()
     // and gets skipped since video exts are already in seenExtensions
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("昨天的视频和包含报告的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Yesterday);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Yesterday);
     // Video extensions
     QVERIFY(intent.fileExtensions().contains("mp4"));
     QVERIFY(intent.fileExtensions().contains("avi"));
@@ -726,8 +726,8 @@ void tst_ChineseNLP::combined_noiseStripping()
     // "帮我找" noise_action, "今天" time, "会议" unconsumed → keyword, "文档" filetype
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("帮我找今天的会议文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
     QVERIFY(!intent.fileExtensions().isEmpty());
     QCOMPARE(intent.keywords().size(), 1);
     QCOMPARE(intent.keywords().first(), QString("会议"));
@@ -738,8 +738,8 @@ void tst_ChineseNLP::combined_fullSentence()
     // "请搜索上周的图片和视频" → noise(请,搜索) + time(上周) + filetype(图片,视频)
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("请搜索上周的图片和视频"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::LastWeek);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::LastWeek);
     QVERIFY(intent.fileExtensions().contains("jpg"));
     QVERIFY(intent.fileExtensions().contains("mp4"));
     QVERIFY(intent.keywords().isEmpty());
@@ -750,7 +750,7 @@ void tst_ChineseNLP::combined_noTime()
     // No time, keyword from "包含数据", filetype from "表格"
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("包含数据的表格"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::None);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::None);
     QVERIFY(!intent.fileExtensions().isEmpty());
     QVERIFY(intent.fileExtensions().contains("xls"));
     QCOMPARE(intent.keywords().size(), 1);
@@ -762,7 +762,7 @@ void tst_ChineseNLP::combined_onlyKeyword()
     // No time, no filetype, only unconsumed text as keyword
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("会议记录"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::None);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::None);
     QVERIFY(intent.fileExtensions().isEmpty());
     QCOMPARE(intent.keywords().size(), 1);
     QCOMPARE(intent.keywords().first(), QString("会议记录"));
@@ -796,17 +796,17 @@ void tst_ChineseNLP::timeCustom_month()
     // "12月" → this month 12
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("12月的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent.timeConstraint().customStart.date().month(), 12);
-    QCOMPARE(intent.timeConstraint().customStart.date().day(), 1);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent.timeConstraint().customStart().date().month(), 12);
+    QCOMPARE(intent.timeConstraint().customStart().date().day(), 1);
     // End should be last day of December
-    QCOMPARE(intent.timeConstraint().customEnd.date().month(), 12);
+    QCOMPARE(intent.timeConstraint().customEnd().date().month(), 12);
 
     // "5月份" — same month, different syntax
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("5月份的图片"), intent2);
-    QCOMPARE(intent2.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent2.timeConstraint().customStart.date().month(), 5);
+    QCOMPARE(intent2.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent2.timeConstraint().customStart().date().month(), 5);
 }
 
 void tst_ChineseNLP::timeCustom_yearMonth()
@@ -814,12 +814,12 @@ void tst_ChineseNLP::timeCustom_yearMonth()
     // "2025年12月" → year=2025, month=12
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("2025年12月的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent.timeConstraint().customStart.date().month(), 12);
-    QCOMPARE(intent.timeConstraint().customStart.date().day(), 1);
-    QCOMPARE(intent.timeConstraint().customEnd.date().year(), 2025);
-    QCOMPARE(intent.timeConstraint().customEnd.date().month(), 12);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent.timeConstraint().customStart().date().month(), 12);
+    QCOMPARE(intent.timeConstraint().customStart().date().day(), 1);
+    QCOMPARE(intent.timeConstraint().customEnd().date().year(), 2025);
+    QCOMPARE(intent.timeConstraint().customEnd().date().month(), 12);
 }
 
 void tst_ChineseNLP::timeCustom_yearMonth_separators()
@@ -827,23 +827,23 @@ void tst_ChineseNLP::timeCustom_yearMonth_separators()
     // "2025-12" — dash separator
     ParsedIntent intent1;
     m_parser->parse(QStringLiteral("2025-12的图片"), intent1);
-    QCOMPARE(intent1.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent1.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent1.timeConstraint().customStart.date().month(), 12);
+    QCOMPARE(intent1.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent1.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent1.timeConstraint().customStart().date().month(), 12);
 
     // "2025/12" — slash separator
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("2025/12的视频"), intent2);
-    QCOMPARE(intent2.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent2.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent2.timeConstraint().customStart.date().month(), 12);
+    QCOMPARE(intent2.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent2.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent2.timeConstraint().customStart().date().month(), 12);
 
     // "25.12" — dot separator, 2-digit year
     ParsedIntent intent3;
     m_parser->parse(QStringLiteral("25.12的文件"), intent3);
-    QCOMPARE(intent3.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent3.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent3.timeConstraint().customStart.date().month(), 12);
+    QCOMPARE(intent3.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent3.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent3.timeConstraint().customStart().date().month(), 12);
 }
 
 void tst_ChineseNLP::timeCustom_date()
@@ -851,12 +851,12 @@ void tst_ChineseNLP::timeCustom_date()
     // "12月5日" → this year, Dec 5
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("12月5日的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent.timeConstraint().customStart.date().month(), 12);
-    QCOMPARE(intent.timeConstraint().customStart.date().day(), 5);
-    QCOMPARE(intent.timeConstraint().customEnd.date().month(), 12);
-    QCOMPARE(intent.timeConstraint().customEnd.date().day(), 5);
-    QCOMPARE(intent.timeConstraint().customStart.date().year(), QDate::currentDate().year());
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent.timeConstraint().customStart().date().month(), 12);
+    QCOMPARE(intent.timeConstraint().customStart().date().day(), 5);
+    QCOMPARE(intent.timeConstraint().customEnd().date().month(), 12);
+    QCOMPARE(intent.timeConstraint().customEnd().date().day(), 5);
+    QCOMPARE(intent.timeConstraint().customStart().date().year(), QDate::currentDate().year());
 }
 
 void tst_ChineseNLP::timeCustom_dateSpoken()
@@ -864,9 +864,9 @@ void tst_ChineseNLP::timeCustom_dateSpoken()
     // "3月8号" — spoken form with 号
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("3月8号的图片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent.timeConstraint().customStart.date().month(), 3);
-    QCOMPARE(intent.timeConstraint().customStart.date().day(), 8);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent.timeConstraint().customStart().date().month(), 3);
+    QCOMPARE(intent.timeConstraint().customStart().date().day(), 8);
 }
 
 void tst_ChineseNLP::timeCustom_fullDate()
@@ -874,16 +874,16 @@ void tst_ChineseNLP::timeCustom_fullDate()
     // "2025年12月30日" — the specific example from requirements
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("2025年12月30日的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent.timeConstraint().customStart.date().month(), 12);
-    QCOMPARE(intent.timeConstraint().customStart.date().day(), 30);
-    QCOMPARE(intent.timeConstraint().customEnd.date().year(), 2025);
-    QCOMPARE(intent.timeConstraint().customEnd.date().month(), 12);
-    QCOMPARE(intent.timeConstraint().customEnd.date().day(), 30);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent.timeConstraint().customStart().date().month(), 12);
+    QCOMPARE(intent.timeConstraint().customStart().date().day(), 30);
+    QCOMPARE(intent.timeConstraint().customEnd().date().year(), 2025);
+    QCOMPARE(intent.timeConstraint().customEnd().date().month(), 12);
+    QCOMPARE(intent.timeConstraint().customEnd().date().day(), 30);
     // Verify time boundaries
-    QCOMPARE(intent.timeConstraint().customStart.time().hour(), 0);
-    QCOMPARE(intent.timeConstraint().customEnd.time().hour(), 23);
+    QCOMPARE(intent.timeConstraint().customStart().time().hour(), 0);
+    QCOMPARE(intent.timeConstraint().customEnd().time().hour(), 23);
 }
 
 void tst_ChineseNLP::timeCustom_fullDate_separators()
@@ -891,26 +891,26 @@ void tst_ChineseNLP::timeCustom_fullDate_separators()
     // "2025-12-05" — dash format
     ParsedIntent intent1;
     m_parser->parse(QStringLiteral("2025-12-05的文档"), intent1);
-    QCOMPARE(intent1.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent1.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent1.timeConstraint().customStart.date().month(), 12);
-    QCOMPARE(intent1.timeConstraint().customStart.date().day(), 5);
+    QCOMPARE(intent1.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent1.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent1.timeConstraint().customStart().date().month(), 12);
+    QCOMPARE(intent1.timeConstraint().customStart().date().day(), 5);
 
     // "2025/12/5" — slash format (no leading zero)
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("2025/12/5的文件"), intent2);
-    QCOMPARE(intent2.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent2.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent2.timeConstraint().customStart.date().month(), 12);
-    QCOMPARE(intent2.timeConstraint().customStart.date().day(), 5);
+    QCOMPARE(intent2.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent2.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent2.timeConstraint().customStart().date().month(), 12);
+    QCOMPARE(intent2.timeConstraint().customStart().date().day(), 5);
 
     // "2025.12.5" — dot format
     ParsedIntent intent3;
     m_parser->parse(QStringLiteral("2025.12.5的图片"), intent3);
-    QCOMPARE(intent3.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent3.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent3.timeConstraint().customStart.date().month(), 12);
-    QCOMPARE(intent3.timeConstraint().customStart.date().day(), 5);
+    QCOMPARE(intent3.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent3.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent3.timeConstraint().customStart().date().month(), 12);
+    QCOMPARE(intent3.timeConstraint().customStart().date().day(), 5);
 }
 
 void tst_ChineseNLP::timeCustom_yesterday_variants_all()
@@ -918,13 +918,13 @@ void tst_ChineseNLP::timeCustom_yesterday_variants_all()
     // "昨天下午" and "昨天晚上" — these are multi-char variants
     ParsedIntent intent1;
     m_parser->parse(QStringLiteral("昨天下午的图片"), intent1);
-    QCOMPARE(intent1.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent1.timeConstraint().preset, TimePreset::Yesterday);
+    QCOMPARE(intent1.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent1.timeConstraint().preset(), TimePreset::Yesterday);
 
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("昨天晚上的视频"), intent2);
-    QCOMPARE(intent2.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent2.timeConstraint().preset, TimePreset::Yesterday);
+    QCOMPARE(intent2.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent2.timeConstraint().preset(), TimePreset::Yesterday);
 }
 
 void tst_ChineseNLP::timeCustom_lastYear_extra()
@@ -933,8 +933,8 @@ void tst_ChineseNLP::timeCustom_lastYear_extra()
     // Current rules only have "去年|上一年". Test that "去年" works.
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("去年的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::LastYear);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::LastYear);
 }
 
 // ===== Filetype All-Synonyms Tests (from requirements) =====
@@ -1101,10 +1101,10 @@ void tst_ChineseNLP::combined_fullDateAndType()
     // Requirements example: "2025年12月30日的文档"
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("2025年12月30日的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent.timeConstraint().customStart.date().month(), 12);
-    QCOMPARE(intent.timeConstraint().customStart.date().day(), 30);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent.timeConstraint().customStart().date().month(), 12);
+    QCOMPARE(intent.timeConstraint().customStart().date().day(), 30);
     // "文档" matches filetype_document_general
     QVERIFY(intent.fileExtensions().contains("doc"));
     QVERIFY(intent.fileExtensions().contains("pdf"));
@@ -1116,8 +1116,8 @@ void tst_ChineseNLP::combined_monthAndType()
     // "12月的图片" — month + image
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("12月的图片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent.timeConstraint().customStart.date().month(), 12);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent.timeConstraint().customStart().date().month(), 12);
     QVERIFY(intent.fileExtensions().contains("jpg"));
     QVERIFY(intent.fileExtensions().contains("png"));
     QVERIFY(intent.keywords().isEmpty());
@@ -1128,9 +1128,9 @@ void tst_ChineseNLP::combined_yearAndType()
     // "2025年的视频" — year + video
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("2025年的视频"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Custom);
-    QCOMPARE(intent.timeConstraint().customStart.date().year(), 2025);
-    QCOMPARE(intent.timeConstraint().customEnd.date().year(), 2025);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Custom);
+    QCOMPARE(intent.timeConstraint().customStart().date().year(), 2025);
+    QCOMPARE(intent.timeConstraint().customEnd().date().year(), 2025);
     QVERIFY(intent.fileExtensions().contains("mp4"));
     QVERIFY(intent.fileExtensions().contains("avi"));
 }
@@ -1142,8 +1142,8 @@ void tst_ChineseNLP::size_fuzzy_large()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("大文件"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().minSize, 524288000LL);   // 500MB
-    QCOMPARE(intent.sizeConstraint().maxSize, 0LL);   // no upper bound
+    QCOMPARE(intent.sizeConstraint().minSize(), 524288000LL);   // 500MB
+    QCOMPARE(intent.sizeConstraint().maxSize(), 0LL);   // no upper bound
 }
 
 void tst_ChineseNLP::size_fuzzy_large_synonyms()
@@ -1163,9 +1163,9 @@ void tst_ChineseNLP::size_fuzzy_small()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("小文件"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().minSize, 0LL);
-    QCOMPARE(intent.sizeConstraint().maxSize, 1048576LL);   // 1MB
-    QCOMPARE(intent.sizeConstraint().includeUpper, false);
+    QCOMPARE(intent.sizeConstraint().minSize(), 0LL);
+    QCOMPARE(intent.sizeConstraint().maxSize(), 1048576LL);   // 1MB
+    QCOMPARE(intent.sizeConstraint().includeUpper(), false);
 }
 
 void tst_ChineseNLP::size_dynamic_min()
@@ -1173,8 +1173,8 @@ void tst_ChineseNLP::size_dynamic_min()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("大于500M的文档"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().minSize, 524288000LL);   // 500MB
-    QVERIFY(intent.sizeConstraint().includeLower);
+    QCOMPARE(intent.sizeConstraint().minSize(), 524288000LL);   // 500MB
+    QVERIFY(intent.sizeConstraint().includeLower());
 }
 
 void tst_ChineseNLP::size_dynamic_max()
@@ -1182,8 +1182,8 @@ void tst_ChineseNLP::size_dynamic_max()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("小于100K的文件"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().maxSize, 102400LL);   // 100KB
-    QCOMPARE(intent.sizeConstraint().minSize, 0LL);
+    QCOMPARE(intent.sizeConstraint().maxSize(), 102400LL);   // 100KB
+    QCOMPARE(intent.sizeConstraint().minSize(), 0LL);
 }
 
 void tst_ChineseNLP::size_dynamic_between()
@@ -1191,8 +1191,8 @@ void tst_ChineseNLP::size_dynamic_between()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("1M-10M的文件"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().minSize, 1048576LL);   // 1MB
-    QCOMPARE(intent.sizeConstraint().maxSize, 10485760LL);   // 10MB
+    QCOMPARE(intent.sizeConstraint().minSize(), 1048576LL);   // 1MB
+    QCOMPARE(intent.sizeConstraint().maxSize(), 10485760LL);   // 10MB
 }
 
 void tst_ChineseNLP::size_chineseUnits_min()
@@ -1200,8 +1200,8 @@ void tst_ChineseNLP::size_chineseUnits_min()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("大于100兆的文件"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().minSize, 104857600LL);   // 100MB
-    QVERIFY(intent.sizeConstraint().includeLower);
+    QCOMPARE(intent.sizeConstraint().minSize(), 104857600LL);   // 100MB
+    QVERIFY(intent.sizeConstraint().includeLower());
 }
 
 void tst_ChineseNLP::size_chineseUnits_max()
@@ -1209,7 +1209,7 @@ void tst_ChineseNLP::size_chineseUnits_max()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("小于50兆的图片"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().maxSize, 52428800LL);   // 50MB
+    QCOMPARE(intent.sizeConstraint().maxSize(), 52428800LL);   // 50MB
 }
 
 void tst_ChineseNLP::size_chineseUnits_range()
@@ -1218,8 +1218,8 @@ void tst_ChineseNLP::size_chineseUnits_range()
     m_parser->parse(QStringLiteral("找下大小在1兆到10兆的文件"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
     QVERIFY(intent.keywords().isEmpty());
-    QCOMPARE(intent.sizeConstraint().minSize, 1048576LL);   // 1MB
-    QCOMPARE(intent.sizeConstraint().maxSize, 10485760LL);   // 10MB
+    QCOMPARE(intent.sizeConstraint().minSize(), 1048576LL);   // 1MB
+    QCOMPARE(intent.sizeConstraint().maxSize(), 10485760LL);   // 10MB
 }
 
 void tst_ChineseNLP::size_noUnit_bytes()
@@ -1227,17 +1227,17 @@ void tst_ChineseNLP::size_noUnit_bytes()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("小于1024的文件"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().maxSize, 1024LL);   // raw bytes
+    QCOMPARE(intent.sizeConstraint().maxSize(), 1024LL);   // raw bytes
 }
 
 void tst_ChineseNLP::size_combined_withTime()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("今天的大文件"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().minSize, 524288000LL);
+    QCOMPARE(intent.sizeConstraint().minSize(), 524288000LL);
 }
 
 void tst_ChineseNLP::size_combined_withType()
@@ -1252,10 +1252,10 @@ void tst_ChineseNLP::size_combined_full()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("昨天大于100M的图片和视频"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Yesterday);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Yesterday);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().minSize, 104857600LL);   // 100MB
+    QCOMPARE(intent.sizeConstraint().minSize(), 104857600LL);   // 100MB
     QVERIFY(intent.fileExtensions().contains("jpg"));
     QVERIFY(intent.fileExtensions().contains("mp4"));
 }
@@ -1266,20 +1266,20 @@ void tst_ChineseNLP::size_suffix_min()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("10M以上的文件"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().minSize, 10485760LL);   // 10MB
-    QCOMPARE(intent.sizeConstraint().maxSize, 0LL);
+    QCOMPARE(intent.sizeConstraint().minSize(), 10485760LL);   // 10MB
+    QCOMPARE(intent.sizeConstraint().maxSize(), 0LL);
 
     // "1G以上" — GB unit
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("1G以上的图片"), intent2);
     QVERIFY(intent2.sizeConstraint().isValid());
-    QCOMPARE(intent2.sizeConstraint().minSize, 1073741824LL);   // 1GB
+    QCOMPARE(intent2.sizeConstraint().minSize(), 1073741824LL);   // 1GB
 
     // "500K以上" — KB unit
     ParsedIntent intent3;
     m_parser->parse(QStringLiteral("500K以上的文档"), intent3);
     QVERIFY(intent3.sizeConstraint().isValid());
-    QCOMPARE(intent3.sizeConstraint().minSize, 512000LL);   // 500KB
+    QCOMPARE(intent3.sizeConstraint().minSize(), 512000LL);   // 500KB
 }
 
 void tst_ChineseNLP::size_suffix_max()
@@ -1288,14 +1288,14 @@ void tst_ChineseNLP::size_suffix_max()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("10M以内的文档"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().minSize, 0LL);
-    QCOMPARE(intent.sizeConstraint().maxSize, 10485760LL);   // 10MB
+    QCOMPARE(intent.sizeConstraint().minSize(), 0LL);
+    QCOMPARE(intent.sizeConstraint().maxSize(), 10485760LL);   // 10MB
 
     // "1G以下" — "以下" variant
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("1G以下的视频"), intent2);
     QVERIFY(intent2.sizeConstraint().isValid());
-    QCOMPARE(intent2.sizeConstraint().maxSize, 1073741824LL);   // 1GB
+    QCOMPARE(intent2.sizeConstraint().maxSize(), 1073741824LL);   // 1GB
 }
 
 void tst_ChineseNLP::size_suffix_combined()
@@ -1305,7 +1305,7 @@ void tst_ChineseNLP::size_suffix_combined()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("10M以上的表格"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().minSize, 10485760LL);   // 10MB
+    QCOMPARE(intent.sizeConstraint().minSize(), 10485760LL);   // 10MB
     QVERIFY(intent.fileExtensions().contains("xls"));
     QVERIFY(intent.fileExtensions().contains("xlsx"));
     QVERIFY(intent.fileExtensions().contains("csv"));
@@ -1314,7 +1314,7 @@ void tst_ChineseNLP::size_suffix_combined()
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("5G以内的压缩包"), intent2);
     QVERIFY(intent2.sizeConstraint().isValid());
-    QCOMPARE(intent2.sizeConstraint().maxSize, 5368709120LL);   // 5GB
+    QCOMPARE(intent2.sizeConstraint().maxSize(), 5368709120LL);   // 5GB
     QVERIFY(intent2.fileExtensions().contains("zip"));
     QVERIFY(intent2.fileExtensions().contains("rar"));
 }
@@ -1325,13 +1325,13 @@ void tst_ChineseNLP::size_suffix_chineseUnits()
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("100兆以上的文件"), intent);
     QVERIFY(intent.sizeConstraint().isValid());
-    QCOMPARE(intent.sizeConstraint().minSize, 104857600LL);   // 100MB
+    QCOMPARE(intent.sizeConstraint().minSize(), 104857600LL);   // 100MB
 
     // "50千以内"
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("50千以内的图片"), intent2);
     QVERIFY(intent2.sizeConstraint().isValid());
-    QCOMPARE(intent2.sizeConstraint().maxSize, 51200LL);   // 50KB
+    QCOMPARE(intent2.sizeConstraint().maxSize(), 51200LL);   // 50KB
 }
 
 // ===== Relative Time Tests =====
@@ -1340,12 +1340,12 @@ void tst_ChineseNLP::timeRelative_justNow()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("刚刚的图片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
     // End should be very close to NOW (within 2 seconds)
-    const qint64 endDelta = qAbs(intent.timeConstraint().customEnd.secsTo(QDateTime::currentDateTime()));
+    const qint64 endDelta = qAbs(intent.timeConstraint().customEnd().secsTo(QDateTime::currentDateTime()));
     QVERIFY2(endDelta < 2, "Relative end should be close to NOW");
     // Start should be ~2 hours ago
-    const qint64 startDelta = qAbs(intent.timeConstraint().customStart.secsTo(QDateTime::currentDateTime().addSecs(-7200)));
+    const qint64 startDelta = qAbs(intent.timeConstraint().customStart().secsTo(QDateTime::currentDateTime().addSecs(-7200)));
     QVERIFY2(startDelta < 2, "Relative start should be ~2h ago");
     QVERIFY(intent.fileExtensions().contains("jpg"));
 }
@@ -1357,7 +1357,7 @@ void tst_ChineseNLP::timeRelative_justNow_synonyms()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input + QStringLiteral("的文档"), intent);
-        QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
+        QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
     }
 }
 
@@ -1365,11 +1365,11 @@ void tst_ChineseNLP::timeRelative_recentDays()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("最近的图片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
     // End = NOW, Start = NOW - 3 days
-    const qint64 endDelta = qAbs(intent.timeConstraint().customEnd.secsTo(QDateTime::currentDateTime()));
+    const qint64 endDelta = qAbs(intent.timeConstraint().customEnd().secsTo(QDateTime::currentDateTime()));
     QVERIFY2(endDelta < 2, "Recent days end should be NOW");
-    const qint64 startDelta = qAbs(intent.timeConstraint().customStart.secsTo(QDateTime::currentDateTime().addSecs(-259200)));
+    const qint64 startDelta = qAbs(intent.timeConstraint().customStart().secsTo(QDateTime::currentDateTime().addSecs(-259200)));
     QVERIFY2(startDelta < 2, "Recent days start should be ~3 days ago");
 }
 
@@ -1380,7 +1380,7 @@ void tst_ChineseNLP::timeRelative_recentDays_synonyms()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input + QStringLiteral("的文件"), intent);
-        QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
+        QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
     }
 }
 
@@ -1388,11 +1388,11 @@ void tst_ChineseNLP::timeRelative_pastFewDays()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("前几天的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
     // End = NOW - 3 days, Start = NOW - 7 days
-    const qint64 endDelta = qAbs(intent.timeConstraint().customEnd.secsTo(QDateTime::currentDateTime().addSecs(-259200)));
+    const qint64 endDelta = qAbs(intent.timeConstraint().customEnd().secsTo(QDateTime::currentDateTime().addSecs(-259200)));
     QVERIFY2(endDelta < 2, "Past few days end should be ~3 days ago");
-    const qint64 startDelta = qAbs(intent.timeConstraint().customStart.secsTo(QDateTime::currentDateTime().addSecs(-604800)));
+    const qint64 startDelta = qAbs(intent.timeConstraint().customStart().secsTo(QDateTime::currentDateTime().addSecs(-604800)));
     QVERIFY2(startDelta < 2, "Past few days start should be ~7 days ago");
 }
 
@@ -1402,7 +1402,7 @@ void tst_ChineseNLP::timeRelative_pastFewDays_synonyms()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input + QStringLiteral("的图片"), intent);
-        QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
+        QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
     }
 }
 
@@ -1410,12 +1410,12 @@ void tst_ChineseNLP::timeRelative_aWhileAgo()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("之前的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
     // End = NOW - 30 days
-    const qint64 endDelta = qAbs(intent.timeConstraint().customEnd.secsTo(QDateTime::currentDateTime().addSecs(-2592000)));
+    const qint64 endDelta = qAbs(intent.timeConstraint().customEnd().secsTo(QDateTime::currentDateTime().addSecs(-2592000)));
     QVERIFY2(endDelta < 2, "A while ago end should be ~30 days ago");
     // Start should be epoch
-    QCOMPARE(intent.timeConstraint().customStart, QDateTime::fromMSecsSinceEpoch(0));
+    QCOMPARE(intent.timeConstraint().customStart(), QDateTime::fromMSecsSinceEpoch(0));
 }
 
 void tst_ChineseNLP::timeRelative_aWhileAgo_synonyms()
@@ -1424,7 +1424,7 @@ void tst_ChineseNLP::timeRelative_aWhileAgo_synonyms()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input + QStringLiteral("的文件"), intent);
-        QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
+        QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
     }
 }
 
@@ -1434,8 +1434,8 @@ void tst_ChineseNLP::timeRelative_priority_vs_preset()
     // "今天之前" — "今天" matches time_today (priority 200), "之前" matches time_a_while_ago (priority 80)
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("今天之前的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
 }
 
 // ===== Dynamic Relative Time Tests =====
@@ -1445,32 +1445,32 @@ void tst_ChineseNLP::timeDynamic_recent_days()
     // "最近3天" — dynamic relative, should consume all 4 chars
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("最近3天"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent.timeConstraint().relativeValue, 3);
-    QCOMPARE(intent.timeConstraint().relativeUnit, TimeUnit::Days);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent.timeConstraint().relativeValue(), 3);
+    QCOMPARE(intent.timeConstraint().relativeUnit(), TimeUnit::Days);
     // Verify time range: ~3 days ago to now
-    const qint64 startDelta = qAbs(intent.timeConstraint().customStart.secsTo(QDateTime::currentDateTime()));
+    const qint64 startDelta = qAbs(intent.timeConstraint().customStart().secsTo(QDateTime::currentDateTime()));
     QVERIFY2(startDelta >= 259000 && startDelta <= 259300, "Start should be ~3 days ago");
 
     // "近3天" — shorter variant
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("近3天的图片"), intent2);
-    QCOMPARE(intent2.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent2.timeConstraint().relativeValue, 3);
-    QCOMPARE(intent2.timeConstraint().relativeUnit, TimeUnit::Days);
+    QCOMPARE(intent2.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent2.timeConstraint().relativeValue(), 3);
+    QCOMPARE(intent2.timeConstraint().relativeUnit(), TimeUnit::Days);
     QVERIFY(intent2.fileExtensions().contains("jpg"));
 
     // "过去7天" — variant
     ParsedIntent intent3;
     m_parser->parse(QStringLiteral("过去7天"), intent3);
-    QCOMPARE(intent3.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent3.timeConstraint().relativeValue, 7);
+    QCOMPARE(intent3.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent3.timeConstraint().relativeValue(), 7);
 
     // "前3天" — variant
     ParsedIntent intent4;
     m_parser->parse(QStringLiteral("前3天的文档"), intent4);
-    QCOMPARE(intent4.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent4.timeConstraint().relativeValue, 3);
+    QCOMPARE(intent4.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent4.timeConstraint().relativeValue(), 3);
 }
 
 void tst_ChineseNLP::timeDynamic_recent_hours()
@@ -1478,15 +1478,15 @@ void tst_ChineseNLP::timeDynamic_recent_hours()
     // "最近2小时" — dynamic relative hours
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("最近2小时的文件"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent.timeConstraint().relativeValue, 2);
-    QCOMPARE(intent.timeConstraint().relativeUnit, TimeUnit::Hours);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent.timeConstraint().relativeValue(), 2);
+    QCOMPARE(intent.timeConstraint().relativeUnit(), TimeUnit::Hours);
 
     // "近1小时" — shorter variant
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("近1小时"), intent2);
-    QCOMPARE(intent2.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent2.timeConstraint().relativeValue, 1);
+    QCOMPARE(intent2.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent2.timeConstraint().relativeValue(), 1);
 }
 
 void tst_ChineseNLP::timeDynamic_recent_weeks()
@@ -1494,11 +1494,11 @@ void tst_ChineseNLP::timeDynamic_recent_weeks()
     // "最近2周" — dynamic relative weeks
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("最近2周的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent.timeConstraint().relativeValue, 2);
-    QCOMPARE(intent.timeConstraint().relativeUnit, TimeUnit::Weeks);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent.timeConstraint().relativeValue(), 2);
+    QCOMPARE(intent.timeConstraint().relativeUnit(), TimeUnit::Weeks);
     // ~14 days
-    const qint64 startDelta = qAbs(intent.timeConstraint().customStart.secsTo(QDateTime::currentDateTime()));
+    const qint64 startDelta = qAbs(intent.timeConstraint().customStart().secsTo(QDateTime::currentDateTime()));
     QVERIFY2(startDelta >= 1209000 && startDelta <= 1210000, "Start should be ~2 weeks ago");
 }
 
@@ -1507,16 +1507,16 @@ void tst_ChineseNLP::timeDynamic_recent_months()
     // "最近3个月" — dynamic relative months
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("最近3个月的图片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent.timeConstraint().relativeValue, 3);
-    QCOMPARE(intent.timeConstraint().relativeUnit, TimeUnit::Months);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent.timeConstraint().relativeValue(), 3);
+    QCOMPARE(intent.timeConstraint().relativeUnit(), TimeUnit::Months);
     QVERIFY(intent.fileExtensions().contains("jpg"));
 
     // "近1月" — shorter variant without "个"
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("近1月的文档"), intent2);
-    QCOMPARE(intent2.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent2.timeConstraint().relativeValue, 1);
+    QCOMPARE(intent2.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent2.timeConstraint().relativeValue(), 1);
 }
 
 void tst_ChineseNLP::timeDynamic_combined_noKeyword()
@@ -1525,9 +1525,9 @@ void tst_ChineseNLP::timeDynamic_combined_noKeyword()
     // Should parse as: time(recent 3 days) + filetype(spreadsheet) — NO keyword
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("最近3天的表格"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent.timeConstraint().relativeValue, 3);
-    QCOMPARE(intent.timeConstraint().relativeUnit, TimeUnit::Days);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent.timeConstraint().relativeValue(), 3);
+    QCOMPARE(intent.timeConstraint().relativeUnit(), TimeUnit::Days);
     // Filetype should be matched
     QVERIFY(intent.fileExtensions().contains("xls"));
     QVERIFY(intent.fileExtensions().contains("xlsx"));
@@ -1539,8 +1539,8 @@ void tst_ChineseNLP::timeDynamic_combined_noKeyword()
     // "过去7天的文档" — same pattern
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("过去7天的文档"), intent2);
-    QCOMPARE(intent2.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent2.timeConstraint().relativeValue, 7);
+    QCOMPARE(intent2.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent2.timeConstraint().relativeValue(), 7);
     QVERIFY(!intent2.fileExtensions().isEmpty());
     QVERIFY2(intent2.keywords().isEmpty(),
              qPrintable(QStringLiteral("Expected no keywords, got: ") + intent2.keywords().join(",")));
@@ -1551,8 +1551,8 @@ void tst_ChineseNLP::timeDynamic_combined_withType()
     // "最近3天的图片和视频" — time + multiple filetypes, no keyword
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("最近3天的图片和视频"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent.timeConstraint().relativeValue, 3);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent.timeConstraint().relativeValue(), 3);
     QVERIFY(intent.fileExtensions().contains("jpg"));
     QVERIFY(intent.fileExtensions().contains("mp4"));
     QVERIFY2(intent.keywords().isEmpty(),
@@ -1561,9 +1561,9 @@ void tst_ChineseNLP::timeDynamic_combined_withType()
     // "近2个月的压缩包" — time + filetype
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("近2个月的压缩包"), intent2);
-    QCOMPARE(intent2.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent2.timeConstraint().relativeValue, 2);
-    QCOMPARE(intent2.timeConstraint().relativeUnit, TimeUnit::Months);
+    QCOMPARE(intent2.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent2.timeConstraint().relativeValue(), 2);
+    QCOMPARE(intent2.timeConstraint().relativeUnit(), TimeUnit::Months);
     QVERIFY(intent2.fileExtensions().contains("zip"));
     QVERIFY2(intent2.keywords().isEmpty(),
              qPrintable(QStringLiteral("Expected no keywords, got: ") + intent2.keywords().join(",")));
@@ -1574,44 +1574,44 @@ void tst_ChineseNLP::timeDynamic_chineseNumerals()
     // "最近一周的图片" — 一 = 1
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("最近一周的图片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent.timeConstraint().relativeValue, 1);
-    QCOMPARE(intent.timeConstraint().relativeUnit, TimeUnit::Weeks);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent.timeConstraint().relativeValue(), 1);
+    QCOMPARE(intent.timeConstraint().relativeUnit(), TimeUnit::Weeks);
     QVERIFY(intent.fileExtensions().contains("jpg"));
     QVERIFY(intent.keywords().isEmpty());
 
     // "最近两周的表格" — 两 = 2
     ParsedIntent intent2;
     m_parser->parse(QStringLiteral("最近两周的表格"), intent2);
-    QCOMPARE(intent2.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent2.timeConstraint().relativeValue, 2);
-    QCOMPARE(intent2.timeConstraint().relativeUnit, TimeUnit::Weeks);
+    QCOMPARE(intent2.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent2.timeConstraint().relativeValue(), 2);
+    QCOMPARE(intent2.timeConstraint().relativeUnit(), TimeUnit::Weeks);
     QVERIFY(intent2.fileExtensions().contains("xls"));
     QVERIFY(intent2.keywords().isEmpty());
 
     // "最近三天的文档" — 三 = 3
     ParsedIntent intent3;
     m_parser->parse(QStringLiteral("最近三天的文档"), intent3);
-    QCOMPARE(intent3.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent3.timeConstraint().relativeValue, 3);
-    QCOMPARE(intent3.timeConstraint().relativeUnit, TimeUnit::Days);
+    QCOMPARE(intent3.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent3.timeConstraint().relativeValue(), 3);
+    QCOMPARE(intent3.timeConstraint().relativeUnit(), TimeUnit::Days);
     QVERIFY(!intent3.fileExtensions().isEmpty());
     QVERIFY(intent3.keywords().isEmpty());
 
     // "近五个月的视频" — 五 = 5
     ParsedIntent intent4;
     m_parser->parse(QStringLiteral("近五个月的视频"), intent4);
-    QCOMPARE(intent4.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent4.timeConstraint().relativeValue, 5);
-    QCOMPARE(intent4.timeConstraint().relativeUnit, TimeUnit::Months);
+    QCOMPARE(intent4.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent4.timeConstraint().relativeValue(), 5);
+    QCOMPARE(intent4.timeConstraint().relativeUnit(), TimeUnit::Months);
     QVERIFY(intent4.fileExtensions().contains("mp4"));
     QVERIFY(intent4.keywords().isEmpty());
 
     // "过去七天" — 七 = 7
     ParsedIntent intent5;
     m_parser->parse(QStringLiteral("过去七天"), intent5);
-    QCOMPARE(intent5.timeConstraint().kind, TimeConstraintKind::Relative);
-    QCOMPARE(intent5.timeConstraint().relativeValue, 7);
+    QCOMPARE(intent5.timeConstraint().kind(), TimeConstraintKind::Relative);
+    QCOMPARE(intent5.timeConstraint().relativeValue(), 7);
 
     // Mixed: Arabic + Chinese should still work
     // "最近3天" already tested above
@@ -1623,11 +1623,11 @@ void tst_ChineseNLP::action_create_birthTime()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("新建的图片"), intent);
-    QCOMPARE(intent.timeConstraint().timeField, TimeField::BirthTime);
+    QCOMPARE(intent.timeConstraint().timeField(), TimeField::BirthTime);
     // Action word should be consumed
     bool actionConsumed = false;
     for (const MatchSpan &span : intent.consumedSpans()) {
-        if (span.ruleId == "action_create") {
+        if (span.ruleId() == "action_create") {
             actionConsumed = true;
             break;
         }
@@ -1642,7 +1642,7 @@ void tst_ChineseNLP::action_create_synonyms()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
-        QCOMPARE(intent.timeConstraint().timeField, TimeField::BirthTime);
+        QCOMPARE(intent.timeConstraint().timeField(), TimeField::BirthTime);
     }
 }
 
@@ -1650,11 +1650,11 @@ void tst_ChineseNLP::action_modify_modifyTime()
 {
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("修改过的图片"), intent);
-    QCOMPARE(intent.timeConstraint().timeField, TimeField::ModifyTime);
+    QCOMPARE(intent.timeConstraint().timeField(), TimeField::ModifyTime);
     // Action word should be consumed
     bool actionConsumed = false;
     for (const MatchSpan &span : intent.consumedSpans()) {
-        if (span.ruleId == "action_modify") {
+        if (span.ruleId() == "action_modify") {
             actionConsumed = true;
             break;
         }
@@ -1669,7 +1669,7 @@ void tst_ChineseNLP::action_modify_synonyms()
     for (const QString &input : inputs) {
         ParsedIntent intent;
         m_parser->parse(input, intent);
-        QCOMPARE(intent.timeConstraint().timeField, TimeField::ModifyTime);
+        QCOMPARE(intent.timeConstraint().timeField(), TimeField::ModifyTime);
     }
 }
 
@@ -1678,9 +1678,9 @@ void tst_ChineseNLP::action_default_unspecified()
     // Without action words, timeField should remain Unspecified
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("今天的图片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
-    QCOMPARE(intent.timeConstraint().timeField, TimeField::Unspecified);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().timeField(), TimeField::Unspecified);
 }
 
 void tst_ChineseNLP::action_combined_withTime_create()
@@ -1688,9 +1688,9 @@ void tst_ChineseNLP::action_combined_withTime_create()
     // "新建的今天的文档" — action_create + time today
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("新建的今天的文档"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
-    QCOMPARE(intent.timeConstraint().timeField, TimeField::BirthTime);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().timeField(), TimeField::BirthTime);
     // Both time and action spans consumed
     int consumedCount = intent.consumedSpans().size();
     QVERIFY2(consumedCount >= 2,
@@ -1702,9 +1702,9 @@ void tst_ChineseNLP::action_combined_withTime_modify()
     // "昨天修改过的图片" — time yesterday + action_modify
     ParsedIntent intent;
     m_parser->parse(QStringLiteral("昨天修改过的图片"), intent);
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Yesterday);
-    QCOMPARE(intent.timeConstraint().timeField, TimeField::ModifyTime);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Yesterday);
+    QCOMPARE(intent.timeConstraint().timeField(), TimeField::ModifyTime);
     QVERIFY(intent.fileExtensions().contains("jpg"));
 }
 
@@ -1782,8 +1782,8 @@ void tst_ChineseNLP::location_noLocation()
     m_parser->parse(QStringLiteral("今天的文档"), intent);
     QVERIFY(intent.searchDirectories().isEmpty());
     QVERIFY(!intent.includeHidden());
-    QCOMPARE(intent.timeConstraint().kind, TimeConstraintKind::Preset);
-    QCOMPARE(intent.timeConstraint().preset, TimePreset::Today);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Today);
 }
 
 void tst_ChineseNLP::location_desktopAndDownload()

--- a/autotests/dfm-search-tests/tst_semantic_search.cpp
+++ b/autotests/dfm-search-tests/tst_semantic_search.cpp
@@ -642,7 +642,7 @@ private Q_SLOTS:
 void tst_ParsedIntent::defaultState()
 {
     ParsedIntent intent;
-    QVERIFY(intent.timeConstraint().kind == TimeConstraintKind::None);
+    QVERIFY(intent.timeConstraint().kind() == TimeConstraintKind::None);
     QVERIFY(intent.fileExtensions().isEmpty());
     QVERIFY(intent.keywords().isEmpty());
     QVERIFY(intent.consumedSpans().isEmpty());
@@ -652,14 +652,14 @@ void tst_ParsedIntent::timeConstraintDefault()
 {
     TimeConstraint tc;
     QVERIFY(!tc.isValid());
-    QCOMPARE(tc.kind, TimeConstraintKind::None);
+    QCOMPARE(tc.kind(), TimeConstraintKind::None);
 }
 
 void tst_ParsedIntent::timeConstraintPreset()
 {
     TimeConstraint tc;
-    tc.kind = TimeConstraintKind::Preset;
-    tc.preset = TimePreset::Today;
+    tc.setKind(TimeConstraintKind::Preset);
+    tc.setPreset(TimePreset::Today);
     QVERIFY(tc.isValid());
 }
 
@@ -668,9 +668,9 @@ void tst_ParsedIntent::matchSpanValidity()
     MatchSpan span;
     QVERIFY(!span.isValid());
 
-    span.start = 0;
-    span.end = 5;
-    span.ruleId = "test_rule";
+    span.setStart(0);
+    span.setEnd(5);
+    span.setRuleId("test_rule");
     QVERIFY(span.isValid());
 }
 

--- a/include/dfm-search/dfm-search/semantic_types.h
+++ b/include/dfm-search/dfm-search/semantic_types.h
@@ -16,17 +16,36 @@
 DFM_SEARCH_BEGIN_NS
 
 class ParsedIntentPrivate;
+class MatchSpanPrivate;
+class TimeConstraintPrivate;
+class SizeConstraintPrivate;
 
 /**
  * @brief Represents a consumed span in the input text matched by a rule.
+ *
+ * Pimpl-based (QSharedDataPointer) for ABI stability.
  */
-struct MatchSpan
+class MatchSpan
 {
-    int start = -1;
-    int end = -1;
-    QString ruleId;
+public:
+    MatchSpan();
+    ~MatchSpan();
+    MatchSpan(const MatchSpan &other);
+    MatchSpan &operator=(const MatchSpan &other);
+    MatchSpan(MatchSpan &&other) noexcept;
+    MatchSpan &operator=(MatchSpan &&other) noexcept;
 
-    bool isValid() const { return start >= 0 && end > start; }
+    int start() const;
+    void setStart(int start);
+    int end() const;
+    void setEnd(int end);
+    QString ruleId() const;
+    void setRuleId(const QString &ruleId);
+
+    bool isValid() const;
+
+private:
+    QSharedDataPointer<MatchSpanPrivate> d;
 };
 
 /**
@@ -56,31 +75,68 @@ enum class TimeConstraintKind {
 
 /**
  * @brief Represents a parsed time constraint from natural language.
+ *
+ * Pimpl-based (QSharedDataPointer) for ABI stability.
  */
-struct TimeConstraint
+class TimeConstraint
 {
-    TimeConstraintKind kind = TimeConstraintKind::None;
-    TimePreset preset = TimePreset::Today;
-    int relativeValue = 0;
-    TimeUnit relativeUnit = TimeUnit::Days;
-    QDateTime customStart;
-    QDateTime customEnd;
-    TimeField timeField = TimeField::Unspecified;   // Set by ActionExtractor; Unspecified = no action specified
+public:
+    TimeConstraint();
+    ~TimeConstraint();
+    TimeConstraint(const TimeConstraint &other);
+    TimeConstraint &operator=(const TimeConstraint &other);
+    TimeConstraint(TimeConstraint &&other) noexcept;
+    TimeConstraint &operator=(TimeConstraint &&other) noexcept;
 
-    bool isValid() const { return kind != TimeConstraintKind::None; }
+    TimeConstraintKind kind() const;
+    void setKind(TimeConstraintKind kind);
+    TimePreset preset() const;
+    void setPreset(TimePreset preset);
+    int relativeValue() const;
+    void setRelativeValue(int value);
+    TimeUnit relativeUnit() const;
+    void setRelativeUnit(TimeUnit unit);
+    QDateTime customStart() const;
+    void setCustomStart(const QDateTime &start);
+    QDateTime customEnd() const;
+    void setCustomEnd(const QDateTime &end);
+    TimeField timeField() const;
+    void setTimeField(TimeField field);
+
+    bool isValid() const;
+
+private:
+    QSharedDataPointer<TimeConstraintPrivate> d;
 };
 
 /**
  * @brief Represents a parsed size constraint from natural language.
+ *
+ * Pimpl-based (QSharedDataPointer) for ABI stability.
  */
-struct SizeConstraint
+class SizeConstraint
 {
-    qint64 minSize = 0;    // Minimum size in bytes (0 = no lower bound)
-    qint64 maxSize = 0;    // Maximum size in bytes (0 = no upper bound)
-    bool includeLower = true;
-    bool includeUpper = true;
+public:
+    SizeConstraint();
+    ~SizeConstraint();
+    SizeConstraint(const SizeConstraint &other);
+    SizeConstraint &operator=(const SizeConstraint &other);
+    SizeConstraint(SizeConstraint &&other) noexcept;
+    SizeConstraint &operator=(SizeConstraint &&other) noexcept;
 
-    bool isValid() const { return minSize > 0 || maxSize > 0; }
+    qint64 minSize() const;
+    void setMinSize(qint64 size);
+    qint64 maxSize() const;
+    void setMaxSize(qint64 size);
+    bool includeLower() const;
+    void setIncludeLower(bool include);
+    bool includeUpper() const;
+    void setIncludeUpper(bool include);
+
+    bool isValid() const;
+
+private:
+    QSharedDataPointer<SizeConstraintPrivate> d;
 };
 
 /**

--- a/src/dfm-search/dfm-search-client/output/json_output.cpp
+++ b/src/dfm-search/dfm-search-client/output/json_output.cpp
@@ -30,12 +30,12 @@ QJsonObject JsonOutput::intentToJson(const DFMSEARCH::ParsedIntent &intent)
     if (intent.timeConstraint().isValid()) {
         QJsonObject time;
         QString kindStr;
-        switch (intent.timeConstraint().kind) {
+        switch (intent.timeConstraint().kind()) {
         case DFMSEARCH::TimeConstraintKind::Preset:
             kindStr = "preset";
             {
                 QString presetStr;
-                switch (intent.timeConstraint().preset) {
+                switch (intent.timeConstraint().preset()) {
                 case DFMSEARCH::TimePreset::Today: presetStr = "today"; break;
                 case DFMSEARCH::TimePreset::Yesterday: presetStr = "yesterday"; break;
                 case DFMSEARCH::TimePreset::DayBeforeYesterday: presetStr = "dayBeforeYesterday"; break;
@@ -51,10 +51,10 @@ QJsonObject JsonOutput::intentToJson(const DFMSEARCH::ParsedIntent &intent)
             break;
         case DFMSEARCH::TimeConstraintKind::Relative:
             kindStr = "relative";
-            time["value"] = intent.timeConstraint().relativeValue;
+            time["value"] = intent.timeConstraint().relativeValue();
             {
                 QString unitStr;
-                switch (intent.timeConstraint().relativeUnit) {
+                switch (intent.timeConstraint().relativeUnit()) {
                 case DFMSEARCH::TimeUnit::Minutes: unitStr = "minutes"; break;
                 case DFMSEARCH::TimeUnit::Hours: unitStr = "hours"; break;
                 case DFMSEARCH::TimeUnit::Days: unitStr = "days"; break;
@@ -67,19 +67,19 @@ QJsonObject JsonOutput::intentToJson(const DFMSEARCH::ParsedIntent &intent)
             break;
         case DFMSEARCH::TimeConstraintKind::Custom:
             kindStr = "custom";
-            if (intent.timeConstraint().customStart.isValid())
-                time["start"] = intent.timeConstraint().customStart.toString(Qt::ISODate);
-            if (intent.timeConstraint().customEnd.isValid())
-                time["end"] = intent.timeConstraint().customEnd.toString(Qt::ISODate);
+            if (intent.timeConstraint().customStart().isValid())
+                time["start"] = intent.timeConstraint().customStart().toString(Qt::ISODate);
+            if (intent.timeConstraint().customEnd().isValid())
+                time["end"] = intent.timeConstraint().customEnd().toString(Qt::ISODate);
             break;
         case DFMSEARCH::TimeConstraintKind::None:
             break;
         }
         time["kind"] = kindStr;
 
-        if (intent.timeConstraint().timeField != DFMSEARCH::TimeField::Unspecified) {
+        if (intent.timeConstraint().timeField() != DFMSEARCH::TimeField::Unspecified) {
             QString fieldStr;
-            switch (intent.timeConstraint().timeField) {
+            switch (intent.timeConstraint().timeField()) {
             case DFMSEARCH::TimeField::ModifyTime: fieldStr = "modifyTime"; break;
             case DFMSEARCH::TimeField::BirthTime: fieldStr = "birthTime"; break;
             case DFMSEARCH::TimeField::Both: fieldStr = "both"; break;
@@ -94,12 +94,12 @@ QJsonObject JsonOutput::intentToJson(const DFMSEARCH::ParsedIntent &intent)
     // sizeConstraint
     if (intent.sizeConstraint().isValid()) {
         QJsonObject size;
-        if (intent.sizeConstraint().minSize > 0)
-            size["minBytes"] = intent.sizeConstraint().minSize;
-        if (intent.sizeConstraint().maxSize > 0)
-            size["maxBytes"] = intent.sizeConstraint().maxSize;
-        size["includeLower"] = intent.sizeConstraint().includeLower;
-        size["includeUpper"] = intent.sizeConstraint().includeUpper;
+        if (intent.sizeConstraint().minSize() > 0)
+            size["minBytes"] = intent.sizeConstraint().minSize();
+        if (intent.sizeConstraint().maxSize() > 0)
+            size["maxBytes"] = intent.sizeConstraint().maxSize();
+        size["includeLower"] = intent.sizeConstraint().includeLower();
+        size["includeUpper"] = intent.sizeConstraint().includeUpper();
         obj["sizeConstraint"] = size;
     }
 
@@ -127,9 +127,9 @@ QJsonObject JsonOutput::intentToJson(const DFMSEARCH::ParsedIntent &intent)
         for (const auto &span : intent.consumedSpans()) {
             if (span.isValid()) {
                 QJsonObject s;
-                s["start"] = span.start;
-                s["end"] = span.end;
-                s["ruleId"] = span.ruleId;
+                s["start"] = span.start();
+                s["end"] = span.end();
+                s["ruleId"] = span.ruleId();
                 spans.append(s);
             }
         }

--- a/src/dfm-search/dfm-search-lib/semantic/extractors/actionextractor.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/extractors/actionextractor.cpp
@@ -47,9 +47,9 @@ void ActionExtractor::extract(const QString &input, ParsedIntent &intent)
             intent.setSearchTarget(SearchTarget::FileNameOnly);
 
             MatchSpan span;
-            span.start = m.capturedStart();
-            span.end = m.capturedEnd();
-            span.ruleId = ruleIds[i];
+            span.setStart(m.capturedStart());
+            span.setEnd(m.capturedEnd());
+            span.setRuleId(ruleIds[i]);
             intent.consumedSpans().append(span);
             continue;
         }
@@ -59,9 +59,9 @@ void ActionExtractor::extract(const QString &input, ParsedIntent &intent)
             intent.setIncludeHidden(true);
 
             MatchSpan span;
-            span.start = m.capturedStart();
-            span.end = m.capturedEnd();
-            span.ruleId = ruleIds[i];
+            span.setStart(m.capturedStart());
+            span.setEnd(m.capturedEnd());
+            span.setRuleId(ruleIds[i]);
             intent.consumedSpans().append(span);
             continue;
         }
@@ -77,9 +77,9 @@ void ActionExtractor::extract(const QString &input, ParsedIntent &intent)
                 }
 
                 MatchSpan span;
-                span.start = m.capturedStart();
-                span.end = m.capturedEnd();
-                span.ruleId = ruleIds[i];
+                span.setStart(m.capturedStart());
+                span.setEnd(m.capturedEnd());
+                span.setRuleId(ruleIds[i]);
                 intent.consumedSpans().append(span);
             }
             // else: no IM directories resolved → do NOT consume span
@@ -89,9 +89,9 @@ void ActionExtractor::extract(const QString &input, ParsedIntent &intent)
 
         // ── Existing time_field actions ──
         if (timeFieldStr == QLatin1String("birth")) {
-            intent.timeConstraint().timeField = TimeField::BirthTime;
+            intent.timeConstraint().setTimeField(TimeField::BirthTime);
         } else if (timeFieldStr == QLatin1String("modify")) {
-            intent.timeConstraint().timeField = TimeField::ModifyTime;
+            intent.timeConstraint().setTimeField(TimeField::ModifyTime);
         } else {
             qWarning() << "Unknown action metadata in rule" << ruleIds[i]
                        << ":" << metadata;
@@ -99,9 +99,9 @@ void ActionExtractor::extract(const QString &input, ParsedIntent &intent)
         }
 
         MatchSpan span;
-        span.start = m.capturedStart();
-        span.end = m.capturedEnd();
-        span.ruleId = ruleIds[i];
+        span.setStart(m.capturedStart());
+        span.setEnd(m.capturedEnd());
+        span.setRuleId(ruleIds[i]);
         intent.consumedSpans().append(span);
     }
 }

--- a/src/dfm-search/dfm-search-lib/semantic/extractors/filetypeextractor.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/extractors/filetypeextractor.cpp
@@ -46,9 +46,9 @@ void FileTypeExtractor::extract(const QString &input, ParsedIntent &intent)
         }
 
         MatchSpan span;
-        span.start = m.capturedStart();
-        span.end = m.capturedEnd();
-        span.ruleId = ruleIds[i];
+        span.setStart(m.capturedStart());
+        span.setEnd(m.capturedEnd());
+        span.setRuleId(ruleIds[i]);
         intent.consumedSpans().append(span);
     }
 

--- a/src/dfm-search/dfm-search-lib/semantic/extractors/keywordextractor.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/extractors/keywordextractor.cpp
@@ -71,9 +71,9 @@ bool KeywordExtractor::extractStructuredKeywords(const QString &input, ParsedInt
 
     // Mark the entire matched region as consumed
     MatchSpan span;
-    span.start = match.capturedStart();
-    span.end = match.capturedEnd();
-    span.ruleId = ruleId;
+    span.setStart(match.capturedStart());
+    span.setEnd(match.capturedEnd());
+    span.setRuleId(ruleId);
     intent.consumedSpans().append(span);
 
     return true;
@@ -91,9 +91,9 @@ void KeywordExtractor::extractUnconsumedText(const QString &input, ParsedIntent 
 
         for (int i = 0; i < noiseMatches.size(); ++i) {
             MatchSpan span;
-            span.start = noiseMatches[i].capturedStart();
-            span.end = noiseMatches[i].capturedEnd();
-            span.ruleId = noiseRuleIds[i];
+            span.setStart(noiseMatches[i].capturedStart());
+            span.setEnd(noiseMatches[i].capturedEnd());
+            span.setRuleId(noiseRuleIds[i]);
             allSpans.append(span);
         }
     }
@@ -145,8 +145,8 @@ QString KeywordExtractor::extractUnconsumedRegions(const QString &input, const Q
     // Build a set of consumed character positions
     QVector<bool> consumed(input.size(), false);
     for (const MatchSpan &span : allSpans) {
-        if (span.isValid() && span.end <= input.size()) {
-            for (int i = span.start; i < span.end; ++i) {
+        if (span.isValid() && span.end() <= input.size()) {
+            for (int i = span.start(); i < span.end(); ++i) {
                 consumed[i] = true;
             }
         }

--- a/src/dfm-search/dfm-search-lib/semantic/extractors/locationextractor.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/extractors/locationextractor.cpp
@@ -41,9 +41,9 @@ void LocationExtractor::extract(const QString &input, ParsedIntent &intent)
         // regardless of whether the resolved directory exists on this machine.
         // This ensures KeywordExtractor correctly excludes trigger words.
         MatchSpan span;
-        span.start = m.capturedStart();
-        span.end = m.capturedEnd();
-        span.ruleId = ruleIds[i];
+        span.setStart(m.capturedStart());
+        span.setEnd(m.capturedEnd());
+        span.setRuleId(ruleIds[i]);
         intent.consumedSpans().append(span);
 
         QStringList resolvedPaths;

--- a/src/dfm-search/dfm-search-lib/semantic/extractors/sizeextractor.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/extractors/sizeextractor.cpp
@@ -34,13 +34,13 @@ void SizeExtractor::extract(const QString &input, ParsedIntent &intent)
     SizeConstraint sc;
 
     if (typeStr == "preset") {
-        sc.minSize = metadata.value("min_bytes", 0).toLongLong();
-        sc.maxSize = metadata.value("max_bytes", 0).toLongLong();
+        sc.setMinSize(metadata.value("min_bytes", 0).toLongLong());
+        sc.setMaxSize(metadata.value("max_bytes", 0).toLongLong());
         if (metadata.contains("include_upper")) {
-            sc.includeUpper = metadata.value("include_upper").toBool();
+            sc.setIncludeUpper(metadata.value("include_upper").toBool());
         }
         if (metadata.contains("include_lower")) {
-            sc.includeLower = metadata.value("include_lower").toBool();
+            sc.setIncludeLower(metadata.value("include_lower").toBool());
         }
     } else if (typeStr == "dynamic") {
         const QString direction = metadata.value("direction").toString();
@@ -52,8 +52,8 @@ void SizeExtractor::extract(const QString &input, ParsedIntent &intent)
             if (bytes <= 0) {
                 return;
             }
-            sc.minSize = bytes;
-            sc.includeLower = true;
+            sc.setMinSize(bytes);
+            sc.setIncludeLower(true);
         } else if (direction == "max") {
             const QString value = match.captured("value");
             const QString unit = normalizeUnit(match.captured("unit"), metadata);
@@ -61,8 +61,8 @@ void SizeExtractor::extract(const QString &input, ParsedIntent &intent)
             if (bytes <= 0) {
                 return;
             }
-            sc.maxSize = bytes;
-            sc.includeUpper = true;
+            sc.setMaxSize(bytes);
+            sc.setIncludeUpper(true);
         } else if (direction == "range") {
             const QString minVal = match.captured("min_val");
             const QString minUnit = normalizeUnit(match.captured("min_unit"), metadata);
@@ -73,17 +73,17 @@ void SizeExtractor::extract(const QString &input, ParsedIntent &intent)
             if (minBytes <= 0 || maxBytes <= 0) {
                 return;
             }
-            sc.minSize = minBytes;
-            sc.maxSize = maxBytes;
+            sc.setMinSize(minBytes);
+            sc.setMaxSize(maxBytes);
         }
     }
 
     if (sc.isValid()) {
         intent.setSizeConstraint(sc);
         MatchSpan span;
-        span.start = match.capturedStart();
-        span.end = match.capturedEnd();
-        span.ruleId = ruleId;
+        span.setStart(match.capturedStart());
+        span.setEnd(match.capturedEnd());
+        span.setRuleId(ruleId);
         intent.consumedSpans().append(span);
     }
 }

--- a/src/dfm-search/dfm-search-lib/semantic/extractors/timeextractor.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/extractors/timeextractor.cpp
@@ -50,8 +50,8 @@ void TimeExtractor::extract(const QString &input, ParsedIntent &intent)
         };
 
         if (kPresetMap.contains(presetStr)) {
-            tc.kind = TimeConstraintKind::Preset;
-            tc.preset = kPresetMap.value(presetStr);
+            tc.setKind(TimeConstraintKind::Preset);
+            tc.setPreset(kPresetMap.value(presetStr));
         }
     } else if (typeStr == "custom") {
         parseCustomTime(match, metadata, tc);
@@ -64,9 +64,9 @@ void TimeExtractor::extract(const QString &input, ParsedIntent &intent)
     if (tc.isValid()) {
         intent.setTimeConstraint(tc);
         MatchSpan span;
-        span.start = match.capturedStart();
-        span.end = match.capturedEnd();
-        span.ruleId = ruleId;
+        span.setStart(match.capturedStart());
+        span.setEnd(match.capturedEnd());
+        span.setRuleId(ruleId);
         intent.consumedSpans().append(span);
     }
 }
@@ -134,21 +134,21 @@ void TimeExtractor::parseCustomTime(const QRegularExpressionMatch &match,
             qWarning() << "Invalid date:" << year << month << day;
             return;
         }
-        tc.kind = TimeConstraintKind::Custom;
-        tc.customStart = QDateTime(date, QTime(0, 0, 0));
-        tc.customEnd = QDateTime(date, QTime(23, 59, 59));
+        tc.setKind(TimeConstraintKind::Custom);
+        tc.setCustomStart(QDateTime(date, QTime(0, 0, 0)));
+        tc.setCustomEnd(QDateTime(date, QTime(23, 59, 59)));
     } else if (month > 0 && day == 0) {
         // Year-month only: entire month
         QDate monthStart(year, month, 1);
         QDate monthEnd(year, month, monthStart.daysInMonth());
-        tc.kind = TimeConstraintKind::Custom;
-        tc.customStart = QDateTime(monthStart, QTime(0, 0, 0));
-        tc.customEnd = QDateTime(monthEnd, QTime(23, 59, 59));
+        tc.setKind(TimeConstraintKind::Custom);
+        tc.setCustomStart(QDateTime(monthStart, QTime(0, 0, 0)));
+        tc.setCustomEnd(QDateTime(monthEnd, QTime(23, 59, 59)));
     } else if (month == 0) {
         // Year only: entire year
-        tc.kind = TimeConstraintKind::Custom;
-        tc.customStart = QDateTime(QDate(year, 1, 1), QTime(0, 0, 0));
-        tc.customEnd = QDateTime(QDate(year, 12, 31), QTime(23, 59, 59));
+        tc.setKind(TimeConstraintKind::Custom);
+        tc.setCustomStart(QDateTime(QDate(year, 1, 1), QTime(0, 0, 0)));
+        tc.setCustomEnd(QDateTime(QDate(year, 12, 31), QTime(23, 59, 59)));
     }
 }
 
@@ -158,14 +158,14 @@ void TimeExtractor::parseRelativeTime(const QVariantMap &metadata, TimeConstrain
     const int agoEndSecs = metadata.value("ago_end_seconds", 0).toInt();
     const int agoStartSecs = metadata.value("ago_start_seconds", 0).toInt();
 
-    tc.kind = TimeConstraintKind::Relative;
-    tc.customEnd = now.addSecs(-agoEndSecs);
+    tc.setKind(TimeConstraintKind::Relative);
+    tc.setCustomEnd(now.addSecs(-agoEndSecs));
 
     if (agoStartSecs < 0) {
         // Sentinel: "from epoch"
-        tc.customStart = QDateTime::fromMSecsSinceEpoch(0);
+        tc.setCustomStart(QDateTime::fromMSecsSinceEpoch(0));
     } else {
-        tc.customStart = now.addSecs(-agoStartSecs);
+        tc.setCustomStart(now.addSecs(-agoStartSecs));
     }
 }
 
@@ -226,11 +226,11 @@ void TimeExtractor::parseDynamicRelativeTime(const QRegularExpressionMatch &matc
     case TimeUnit::Months: {
         // Approximate: use average days per month
         const QDate startDate = now.addMonths(-value).date();
-        tc.kind = TimeConstraintKind::Relative;
-        tc.customStart = QDateTime(startDate, QTime(0, 0, 0));
-        tc.customEnd = now;
-        tc.relativeValue = value;
-        tc.relativeUnit = unit;
+        tc.setKind(TimeConstraintKind::Relative);
+        tc.setCustomStart(QDateTime(startDate, QTime(0, 0, 0)));
+        tc.setCustomEnd(now);
+        tc.setRelativeValue(value);
+        tc.setRelativeUnit(unit);
         return;
     }
     case TimeUnit::Years:
@@ -238,11 +238,11 @@ void TimeExtractor::parseDynamicRelativeTime(const QRegularExpressionMatch &matc
         break;
     }
 
-    tc.kind = TimeConstraintKind::Relative;
-    tc.customStart = now.addSecs(-totalSeconds);
-    tc.customEnd = now;
-    tc.relativeValue = value;
-    tc.relativeUnit = unit;
+    tc.setKind(TimeConstraintKind::Relative);
+    tc.setCustomStart(now.addSecs(-totalSeconds));
+    tc.setCustomEnd(now);
+    tc.setRelativeValue(value);
+    tc.setRelativeUnit(unit);
 }
 
 int TimeExtractor::localeAwareToInt(const QString &input,

--- a/src/dfm-search/dfm-search-lib/semantic/semanticquerybuilder.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/semanticquerybuilder.cpp
@@ -30,12 +30,12 @@ SemanticSearchPlan SemanticQueryBuilder::build(const ParsedIntent &intent)
             : intent.searchTarget();
 
     // Determine time field strategy
-    if (intent.timeConstraint().isValid() && intent.timeConstraint().timeField == TimeField::Unspecified) {
+    if (intent.timeConstraint().isValid() && intent.timeConstraint().timeField() == TimeField::Unspecified) {
         // Time constraint exists but no action specified → search both birth and modify time
         plan.timeField = TimeField::Both;
-    } else if (intent.timeConstraint().timeField == TimeField::BirthTime) {
+    } else if (intent.timeConstraint().timeField() == TimeField::BirthTime) {
         plan.timeField = TimeField::BirthTime;
-    } else if (intent.timeConstraint().timeField == TimeField::ModifyTime) {
+    } else if (intent.timeConstraint().timeField() == TimeField::ModifyTime) {
         plan.timeField = TimeField::ModifyTime;
     } else {
         plan.timeField = TimeField::ModifyTime;
@@ -162,9 +162,9 @@ TimeRangeFilter SemanticQueryBuilder::buildTimeRangeFilter(const TimeConstraint 
         return filter;
     }
 
-    switch (tc.kind) {
+    switch (tc.kind()) {
     case TimeConstraintKind::Preset:
-        switch (tc.preset) {
+        switch (tc.preset()) {
         case TimePreset::Today:
             filter.setToday();
             break;
@@ -199,19 +199,19 @@ TimeRangeFilter SemanticQueryBuilder::buildTimeRangeFilter(const TimeConstraint 
         }
         break;
     case TimeConstraintKind::Relative:
-        filter.setRange(tc.customStart, tc.customEnd);
+        filter.setRange(tc.customStart(), tc.customEnd());
         break;
     case TimeConstraintKind::Custom:
-        filter.setRange(tc.customStart, tc.customEnd);
+        filter.setRange(tc.customStart(), tc.customEnd());
         break;
     case TimeConstraintKind::None:
         break;
     }
 
     // Set time field on the filter
-    if (tc.timeField == TimeField::BirthTime || tc.timeField == TimeField::ModifyTime) {
-        filter.setTimeField(tc.timeField);
-    } else if (tc.timeField == TimeField::Unspecified || tc.timeField == TimeField::Both) {
+    if (tc.timeField() == TimeField::BirthTime || tc.timeField() == TimeField::ModifyTime) {
+        filter.setTimeField(tc.timeField());
+    } else if (tc.timeField() == TimeField::Unspecified || tc.timeField() == TimeField::Both) {
         // No specific time field or both requested → search both birth and modify time
         filter.setTimeField(TimeField::Both);
     }
@@ -225,10 +225,10 @@ SizeRangeFilter SemanticQueryBuilder::buildSizeRangeFilter(const SizeConstraint 
     if (!sc.isValid()) {
         return filter;
     }
-    filter.setMin(sc.minSize);
-    filter.setMax(sc.maxSize);
-    filter.setIncludeLower(sc.includeLower);
-    filter.setIncludeUpper(sc.includeUpper);
+    filter.setMin(sc.minSize());
+    filter.setMax(sc.maxSize());
+    filter.setIncludeLower(sc.includeLower());
+    filter.setIncludeUpper(sc.includeUpper());
     return filter;
 }
 

--- a/src/dfm-search/dfm-search-lib/utils/semanticvalue.cpp
+++ b/src/dfm-search/dfm-search-lib/utils/semanticvalue.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "semanticvalue_p.h"
+
+#include <dfm-search/semantic_types.h>
+
+DFM_SEARCH_BEGIN_NS
+
+// ── MatchSpan ──────────────────────────────────────────────────────
+
+MatchSpan::MatchSpan()
+    : d(new MatchSpanPrivate)
+{
+}
+
+MatchSpan::~MatchSpan() = default;
+MatchSpan::MatchSpan(const MatchSpan &other) = default;
+MatchSpan &MatchSpan::operator=(const MatchSpan &other) = default;
+MatchSpan::MatchSpan(MatchSpan &&other) noexcept = default;
+MatchSpan &MatchSpan::operator=(MatchSpan &&other) noexcept = default;
+
+int MatchSpan::start() const { return d->start; }
+void MatchSpan::setStart(int start) { d->start = start; }
+int MatchSpan::end() const { return d->end; }
+void MatchSpan::setEnd(int end) { d->end = end; }
+QString MatchSpan::ruleId() const { return d->ruleId; }
+void MatchSpan::setRuleId(const QString &ruleId) { d->ruleId = ruleId; }
+
+bool MatchSpan::isValid() const
+{
+    return d->start >= 0 && d->end > d->start;
+}
+
+// ── TimeConstraint ─────────────────────────────────────────────────
+
+TimeConstraint::TimeConstraint()
+    : d(new TimeConstraintPrivate)
+{
+}
+
+TimeConstraint::~TimeConstraint() = default;
+TimeConstraint::TimeConstraint(const TimeConstraint &other) = default;
+TimeConstraint &TimeConstraint::operator=(const TimeConstraint &other) = default;
+TimeConstraint::TimeConstraint(TimeConstraint &&other) noexcept = default;
+TimeConstraint &TimeConstraint::operator=(TimeConstraint &&other) noexcept = default;
+
+TimeConstraintKind TimeConstraint::kind() const { return d->kind; }
+void TimeConstraint::setKind(TimeConstraintKind kind) { d->kind = kind; }
+TimePreset TimeConstraint::preset() const { return d->preset; }
+void TimeConstraint::setPreset(TimePreset preset) { d->preset = preset; }
+int TimeConstraint::relativeValue() const { return d->relativeValue; }
+void TimeConstraint::setRelativeValue(int value) { d->relativeValue = value; }
+TimeUnit TimeConstraint::relativeUnit() const { return d->relativeUnit; }
+void TimeConstraint::setRelativeUnit(TimeUnit unit) { d->relativeUnit = unit; }
+QDateTime TimeConstraint::customStart() const { return d->customStart; }
+void TimeConstraint::setCustomStart(const QDateTime &start) { d->customStart = start; }
+QDateTime TimeConstraint::customEnd() const { return d->customEnd; }
+void TimeConstraint::setCustomEnd(const QDateTime &end) { d->customEnd = end; }
+TimeField TimeConstraint::timeField() const { return d->timeField; }
+void TimeConstraint::setTimeField(TimeField field) { d->timeField = field; }
+
+bool TimeConstraint::isValid() const
+{
+    return d->kind != TimeConstraintKind::None;
+}
+
+// ── SizeConstraint ─────────────────────────────────────────────────
+
+SizeConstraint::SizeConstraint()
+    : d(new SizeConstraintPrivate)
+{
+}
+
+SizeConstraint::~SizeConstraint() = default;
+SizeConstraint::SizeConstraint(const SizeConstraint &other) = default;
+SizeConstraint &SizeConstraint::operator=(const SizeConstraint &other) = default;
+SizeConstraint::SizeConstraint(SizeConstraint &&other) noexcept = default;
+SizeConstraint &SizeConstraint::operator=(SizeConstraint &&other) noexcept = default;
+
+qint64 SizeConstraint::minSize() const { return d->minSize; }
+void SizeConstraint::setMinSize(qint64 size) { d->minSize = size; }
+qint64 SizeConstraint::maxSize() const { return d->maxSize; }
+void SizeConstraint::setMaxSize(qint64 size) { d->maxSize = size; }
+bool SizeConstraint::includeLower() const { return d->includeLower; }
+void SizeConstraint::setIncludeLower(bool include) { d->includeLower = include; }
+bool SizeConstraint::includeUpper() const { return d->includeUpper; }
+void SizeConstraint::setIncludeUpper(bool include) { d->includeUpper = include; }
+
+bool SizeConstraint::isValid() const
+{
+    return d->minSize > 0 || d->maxSize > 0;
+}
+
+DFM_SEARCH_END_NS

--- a/src/dfm-search/dfm-search-lib/utils/semanticvalue_p.h
+++ b/src/dfm-search/dfm-search-lib/utils/semanticvalue_p.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SEMANTICVALUE_P_H
+#define SEMANTICVALUE_P_H
+
+#include <QDateTime>
+#include <QSharedData>
+#include <QString>
+
+#include <dfm-search/dsearch_global.h>
+#include <dfm-search/semantic_types.h>
+
+DFM_SEARCH_BEGIN_NS
+
+class MatchSpanPrivate : public QSharedData
+{
+public:
+    MatchSpanPrivate() = default;
+    int start = -1;
+    int end = -1;
+    QString ruleId;
+};
+
+class TimeConstraintPrivate : public QSharedData
+{
+public:
+    TimeConstraintPrivate() = default;
+    TimeConstraintKind kind = TimeConstraintKind::None;
+    TimePreset preset = TimePreset::Today;
+    int relativeValue = 0;
+    TimeUnit relativeUnit = TimeUnit::Days;
+    QDateTime customStart;
+    QDateTime customEnd;
+    TimeField timeField = TimeField::Unspecified;
+};
+
+class SizeConstraintPrivate : public QSharedData
+{
+public:
+    SizeConstraintPrivate() = default;
+    qint64 minSize = 0;
+    qint64 maxSize = 0;
+    bool includeLower = true;
+    bool includeUpper = true;
+};
+
+DFM_SEARCH_END_NS
+
+#endif   // SEMANTICVALUE_P_H


### PR DESCRIPTION
Refactored semantic types MatchSpan, TimeConstraint, and SizeConstraint
to use PIMPL pattern for better ABI stability and encapsulation. Changed
all direct member access to use getter/setter methods.

1. Moved all internal data members to Private classes
2. Added proper copy/move constructors and operators
3. Maintained all existing functionality while improving encapsulation

Influence:
1. All test cases need to be updated to use getter methods
2. Client code needs to be updated to use getter/setter methods instead
of direct member access

refactor: 重构语义类型使用PIMPL模式

将语义类型MatchSpan、TimeConstraint和SizeConstraint重构为使用PIMPL模式，
以提高ABI稳定性和封装性。将所有直接成员访问改为使用getter/setter方法。

1. 将所有内部数据成员移至Private类
2. 添加了正确的拷贝/移动构造函数和运算符
3. 在提高封装性的同时保持了所有现有功能

影响:
1. 需要更新所有测试用例以使用getter方法
2. 需要更新客户端代码以使用getter/setter方法而非直接成员访问
