### PR TITLE
fix(dfm-io): close FTS tree in destructor to prevent memory leak

### DIFF
--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -41,6 +41,10 @@ DEnumeratorPrivate::~DEnumeratorPrivate()
         g_object_unref(cancellable);
         cancellable = nullptr;
     }
+    if (fts) {
+        fts_close(fts);
+        fts = nullptr;
+    }
 }
 
 bool DEnumeratorPrivate::init(const QUrl &url)


### PR DESCRIPTION
When initEnumerator(false) is called, openDirByfts() allocates an FTS tree via fts_open().  However, LocalDirIterator::sortFileInfoList() uses its own opendir()/readdir()/closedir() implementation and never calls fts_close(), leaving the FTS tree (5,279 bytes including indirect allocations) leaked.

Close the FTS tree in the destructor as a safety net so it is always freed regardless of which sortFileInfoList() code path is taken.

Log: Fixed FTS tree memory leak when LocalDirIterator bypasses fts_close().

Assisted-by: deepseek-v4-pro

Influence:
1. Open a local directory with dde-file-manager - verify no fts_open leak under Valgrind
2. Test batch directory traversal with sort role set (sortFileInfoList path)
3. Verify one-by-one enumeration path is unaffected
4. Test vault and SMB directory traversal paths
5. Verify rapid open/close of file manager window does not accumulate fts_open leaks

fix(dfm-io): 在析构函数中关闭 FTS 树以防止内存泄露

initEnumerator(false) 调用 openDirByfts() 通过 fts_open() 分配 FTS 树，但 LocalDirIterator::sortFileInfoList() 使用自己的 opendir()/readdir()/closedir() 实现，从未调用 fts_close()， 导致 FTS 树（含间接分配共 5,279 字节）泄露。

在析构函数中添加 fts_close() 作为安全兜底，确保无论走哪个
sortFileInfoList() 代码路径，FTS 树都能被释放。

Log: 修复 LocalDirIterator 绕过 fts_close() 导致的 FTS 树内存泄露。

Influence:
1. 使用 dde-file-manager 打开本地目录 — Valgrind 下验证 fts_open 无泄露
2. 测试设置排序角色后的批量目录遍历（sortFileInfoList 路径）
3. 验证逐个遍历路径不受影响
4. 测试保险箱和 SMB 目录遍历路径
5. 验证快速打开/关闭文件管理器窗口不累积 fts_open 泄露

## Summary by Sourcery

Bug Fixes:
- Fix a memory leak by closing any open FTS tree in the DEnumeratorPrivate destructor.