### PR TITLE
feat: implement recent files search via DBus RecentManager

### DIFF
--- a/autotests/dfm-search-tests/tst_chinese_nlp.cpp
+++ b/autotests/dfm-search-tests/tst_chinese_nlp.cpp
@@ -182,6 +182,16 @@ private Q_SLOTS:
     void action_combined_withTime_create();
     void action_combined_withTime_modify();
 
+    // Action: recently-used files (DBus RecentManager data source)
+    void action_recent_basic();
+    void action_recent_synonyms();
+    void action_recent_timeFieldForced();
+    void action_recent_combined_withTime();
+    void action_recent_combined_withFiletype();
+    void action_recent_combined_withKeyword();
+    void action_recent_notTriggered_byBareVerb();
+    void action_recent_consumesTriggerWords();
+
     // Keyword tests
     void keyword_contains_single();
     void keyword_contains_multi();
@@ -1706,6 +1716,139 @@ void tst_ChineseNLP::action_combined_withTime_modify()
     QCOMPARE(intent.timeConstraint().preset(), TimePreset::Yesterday);
     QCOMPARE(intent.timeConstraint().timeField(), TimeField::ModifyTime);
     QVERIFY(intent.fileExtensions().contains("jpg"));
+}
+
+// ===== Action: Recently-Used Files Tests =====
+// action_recent rule (pattern: 打开过的|看过的|浏览过的|读过的|点开过的)
+// routes to the DBus RecentManager data source via intent.recentOnly.
+
+void tst_ChineseNLP::action_recent_basic()
+{
+    // "打开过的文件" → recentOnly=true, span consumed with ruleId action_recent
+    ParsedIntent intent;
+    m_parser->parse(QStringLiteral("打开过的文件"), intent);
+    QVERIFY2(intent.recentOnly(),
+             "打开过的 should set recentOnly=true");
+    QCOMPARE(intent.timeConstraint().timeField(), TimeField::ModifyTime);
+
+    bool actionConsumed = false;
+    for (const MatchSpan &span : intent.consumedSpans()) {
+        if (span.ruleId() == QLatin1String("action_recent")) {
+            actionConsumed = true;
+            break;
+        }
+    }
+    QVERIFY2(actionConsumed, "action_recent should produce a consumed span");
+}
+
+void tst_ChineseNLP::action_recent_synonyms()
+{
+    // All five synonyms from the requirements must trigger recentOnly.
+    const QStringList inputs = {
+        QStringLiteral("打开过的文件"),
+        QStringLiteral("看过的文档"),
+        QStringLiteral("浏览过的图片"),
+        QStringLiteral("读过的pdf"),
+        QStringLiteral("点开过的视频"),
+    };
+    for (const QString &input : inputs) {
+        ParsedIntent intent;
+        m_parser->parse(input, intent);
+        QVERIFY2(intent.recentOnly(),
+                 qPrintable(QStringLiteral("recentOnly not set for: ") + input));
+        QCOMPARE(intent.timeConstraint().timeField(), TimeField::ModifyTime);
+    }
+}
+
+void tst_ChineseNLP::action_recent_timeFieldForced()
+{
+    // Even when no explicit time constraint is given, action_recent must
+    // force timeField=ModifyTime because recent records only carry modified.
+    ParsedIntent intent;
+    m_parser->parse(QStringLiteral("看过的"), intent);
+    QVERIFY(intent.recentOnly());
+    QCOMPARE(intent.timeConstraint().timeField(), TimeField::ModifyTime);
+}
+
+void tst_ChineseNLP::action_recent_combined_withTime()
+{
+    // "昨天看过的" → time yesterday + recentOnly
+    ParsedIntent intent;
+    m_parser->parse(QStringLiteral("昨天看过的文件"), intent);
+    QCOMPARE(intent.timeConstraint().kind(), TimeConstraintKind::Preset);
+    QCOMPARE(intent.timeConstraint().preset(), TimePreset::Yesterday);
+    QCOMPARE(intent.timeConstraint().timeField(), TimeField::ModifyTime);
+    QVERIFY(intent.recentOnly());
+}
+
+void tst_ChineseNLP::action_recent_combined_withFiletype()
+{
+    // "看过的pdf" → recentOnly + filetype pdf
+    ParsedIntent intent;
+    m_parser->parse(QStringLiteral("看过的pdf"), intent);
+    QVERIFY(intent.recentOnly());
+    QVERIFY(intent.fileExtensions().contains("pdf"));
+
+    // "浏览过的图片" → recentOnly + image extensions
+    ParsedIntent intent2;
+    m_parser->parse(QStringLiteral("浏览过的图片"), intent2);
+    QVERIFY(intent2.recentOnly());
+    QVERIFY(intent2.fileExtensions().contains("jpg"));
+}
+
+void tst_ChineseNLP::action_recent_combined_withKeyword()
+{
+    // "看过的预算" → action consumes "看过的", remaining "预算" becomes keyword.
+    // "预算" is not a filetype, so it falls through to keyword extraction.
+    ParsedIntent intent;
+    m_parser->parse(QStringLiteral("看过的预算"), intent);
+    QVERIFY(intent.recentOnly());
+    QCOMPARE(intent.keywords().size(), 1);
+    QCOMPARE(intent.keywords().first(), QString("预算"));
+}
+
+void tst_ChineseNLP::action_recent_notTriggered_byBareVerb()
+{
+    // Bare verb without "过的" suffix must NOT trigger recent (avoids false positives).
+    // "打开文件" is a plain command, not a recent-files query.
+    ParsedIntent intent;
+    m_parser->parse(QStringLiteral("打开文件"), intent);
+    QVERIFY2(!intent.recentOnly(),
+             "打开 (without 过的) must not trigger recentOnly");
+
+    // "看文件" — also bare
+    ParsedIntent intent2;
+    m_parser->parse(QStringLiteral("看文件"), intent2);
+    QVERIFY(!intent2.recentOnly());
+}
+
+void tst_ChineseNLP::action_recent_consumesTriggerWords()
+{
+    // Trigger words must be fully consumed and not leak into keywords.
+    const struct {
+        const char *input;
+        const char *trigger;   // must NOT appear in any keyword
+    } cases[] = {
+        { "打开过的报告", "打开" },
+        { "看过的文档", "看过" },
+        { "浏览过的图片", "浏览" },
+        { "读过的pdf", "读过" },
+        { "点开过的视频", "点开" },
+    };
+
+    for (const auto &c : cases) {
+        ParsedIntent intent;
+        m_parser->parse(QString::fromUtf8(c.input), intent);
+        QVERIFY2(intent.recentOnly(),
+                 qUtf8Printable("recentOnly not set for: " + QString::fromUtf8(c.input)));
+        for (const QString &kw : intent.keywords()) {
+            QVERIFY2(!kw.contains(QString::fromUtf8(c.trigger)),
+                     qUtf8Printable(QString("Keyword '%1' must not contain trigger '%2' (input: %3)")
+                                            .arg(kw)
+                                            .arg(QString::fromUtf8(c.trigger))
+                                            .arg(c.input)));
+        }
+    }
 }
 
 // ===== Location Tests =====

--- a/include/dfm-search/dfm-search/dsearch_global.h
+++ b/include/dfm-search/dfm-search/dsearch_global.h
@@ -203,6 +203,7 @@ enum SearchType {
     FileName,   // Search by file name
     Content,   // Search by content within files
     Ocr,   // Search by OCR-extracted text from images
+    Recent = 10,   // Search recently-used files (DBus RecentManager data source)
     Semantic = 40,   // Semantic / natural-language search (launches sub-engines internally)
     Custom = 50   // User-defined search type
 };

--- a/include/dfm-search/dfm-search/semantic_types.h
+++ b/include/dfm-search/dfm-search/semantic_types.h
@@ -200,6 +200,10 @@ public:
     bool hiddenOnly() const;
     void setHiddenOnly(bool hidden);
 
+    // recentOnly — true means search recently-used files via DBus RecentManager
+    bool recentOnly() const;
+    void setRecentOnly(bool recent);
+
     // keywords
     const QStringList &keywords() const;
     QStringList &keywords();

--- a/src/dfm-search/dfm-search-lib/core/searchengine.cpp
+++ b/src/dfm-search/dfm-search-lib/core/searchengine.cpp
@@ -10,6 +10,7 @@
 #include "contentsearch/contentsearchengine.h"
 #include "filenamesearch/filenamesearchengine.h"
 #include "ocrtextsearch/ocrtextsearchengine.h"
+#include "recentsearch/recentsearchengine.h"
 
 DFM_SEARCH_BEGIN_NS
 
@@ -60,6 +61,9 @@ void SearchEngine::setSearchType(SearchType type)
         break;
     case SearchType::Ocr:
         d_ptr = std::make_unique<OcrTextSearchEngine>();
+        break;
+    case SearchType::Recent:
+        d_ptr = std::make_unique<RecentSearchEngine>();
         break;
     default:
         qWarning("Unsupported search type: %d", static_cast<int>(type));

--- a/src/dfm-search/dfm-search-lib/core/searchfactory.cpp
+++ b/src/dfm-search/dfm-search-lib/core/searchfactory.cpp
@@ -20,6 +20,9 @@ SearchEngine *SearchFactory::createEngine(SearchType type, QObject *parent)
     case SearchType::Ocr:
         engine = new SearchEngine(type, parent);
         break;
+    case SearchType::Recent:
+        engine = new SearchEngine(type, parent);
+        break;
     case SearchType::Semantic:
     case SearchType::Custom:
         // TODO: Created by application based on provider

--- a/src/dfm-search/dfm-search-lib/dfm-search.cmake
+++ b/src/dfm-search/dfm-search-lib/dfm-search.cmake
@@ -1,5 +1,5 @@
 # Setup the environment
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core DBus REQUIRED)
 find_package(Dtk${DFM_VERSION_MAJOR} COMPONENTS Core REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Boost REQUIRED)
@@ -24,6 +24,7 @@ target_compile_definitions(${BIN_NAME} PRIVATE
 
 target_link_libraries(${BIN_NAME} PUBLIC
     Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::DBus
     Dtk${DFM_VERSION_MAJOR}::Core
     PkgConfig::Lucene
     Threads::Threads
@@ -89,7 +90,7 @@ install(DIRECTORY
 # for pc file config - update to include all dependencies
 set(PC_LIBS_PRIVATE Qt${QT_VERSION_MAJOR}Core dtk${DFM_VERSION_MAJOR}core)
 set(PC_REQ_PRIVATE liblucene++ liblucene++-contrib)
-set(PC_REQ_PUBLIC Qt${QT_VERSION_MAJOR}Core dtk${DFM_VERSION_MAJOR}core)
+set(PC_REQ_PUBLIC Qt${QT_VERSION_MAJOR}Core Qt${QT_VERSION_MAJOR}DBus dtk${DFM_VERSION_MAJOR}core)
 
 # config pkgconfig file
 configure_file(${PROJECT_SOURCE_DIR}/misc/${BASE_NAME}/${BASE_NAME}.pc.in ${BIN_NAME}.pc @ONLY)

--- a/src/dfm-search/dfm-search-lib/recentsearch/recentsearchengine.cpp
+++ b/src/dfm-search/dfm-search-lib/recentsearch/recentsearchengine.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "recentsearchengine.h"
+#include "recentstrategies/recentsearchstrategy.h"
+
+#include <dfm-search/searcherror.h>
+
+DFM_SEARCH_BEGIN_NS
+
+RecentSearchEngine::RecentSearchEngine(QObject *parent)
+    : GenericSearchEngine(parent)
+{
+}
+
+RecentSearchEngine::~RecentSearchEngine() = default;
+
+void RecentSearchEngine::setupStrategyFactory()
+{
+    auto factory = std::make_unique<RecentSearchStrategyFactory>();
+    m_worker->setStrategyFactory(std::move(factory));
+}
+
+SearchError RecentSearchEngine::validateSearchConditions()
+{
+    // 最近使用搜索不依赖搜索路径（数据来自 DBus），跳过基类的路径校验。
+    // 也不要求关键词非空——"看过的" 单独使用时应返回全部最近文件。
+    return SearchError();
+}
+
+std::unique_ptr<BaseSearchStrategy> RecentSearchStrategyFactory::createStrategy(
+        SearchType searchType, const SearchOptions &options)
+{
+    if (searchType != SearchType::Recent) {
+        return nullptr;
+    }
+    return std::make_unique<RecentSearchStrategy>(options);
+}
+
+DFM_SEARCH_END_NS

--- a/src/dfm-search/dfm-search-lib/recentsearch/recentsearchengine.h
+++ b/src/dfm-search/dfm-search-lib/recentsearch/recentsearchengine.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef RECENTSEARCHENGINE_H
+#define RECENTSEARCHENGINE_H
+
+#include "core/genericsearchengine.h"
+
+DFM_SEARCH_BEGIN_NS
+
+/**
+ * @brief 搜索引擎：最近使用文件（DBus RecentManager 数据源）
+ *
+ * 数据源为 org.deepin.Filemanager.Daemon.RecentManager.GetItemsInfo，
+ * 返回 JSON 数组，每条含 Href/Path/modified。
+ *
+ * 该引擎不复用 lucene++ 索引——最近使用记录不在索引中，
+ * 因此所有 filename/content 搜索路径都无法触及此数据。
+ */
+class RecentSearchEngine : public GenericSearchEngine
+{
+    Q_OBJECT
+
+public:
+    explicit RecentSearchEngine(QObject *parent = nullptr);
+    ~RecentSearchEngine() override;
+
+    SearchType searchType() const override { return SearchType::Recent; }
+
+protected:
+    void setupStrategyFactory() override;
+    SearchError validateSearchConditions() override;
+};
+
+/**
+ * @brief 策略工厂：始终创建 RecentSearchStrategy（无 indexed/realtime 分支）
+ */
+class RecentSearchStrategyFactory : public SearchStrategyFactory
+{
+public:
+    std::unique_ptr<BaseSearchStrategy> createStrategy(
+            SearchType searchType, const SearchOptions &options) override;
+};
+
+DFM_SEARCH_END_NS
+
+#endif   // RECENTSEARCHENGINE_H

--- a/src/dfm-search/dfm-search-lib/recentsearch/recentstrategies/recentsearchstrategy.cpp
+++ b/src/dfm-search/dfm-search-lib/recentsearch/recentstrategies/recentsearchstrategy.cpp
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "recentsearchstrategy.h"
+
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusReply>
+#include <QElapsedTimer>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QFileInfo>
+#include <QDateTime>
+#include <QDebug>
+
+DFM_SEARCH_BEGIN_NS
+
+namespace {
+constexpr auto kDBusService = "org.deepin.Filemanager.Daemon.RecentManager";
+constexpr auto kDBusPath = "/org/deepin/Filemanager/Daemon/RecentManager";
+constexpr auto kDBusInterface = "org.deepin.Filemanager.Daemon.RecentManager";
+constexpr auto kDBusMethod = "GetItemsInfo";
+}   // namespace
+
+RecentSearchStrategy::RecentSearchStrategy(const SearchOptions &options, QObject *parent)
+    : BaseSearchStrategy(options, parent)
+{
+}
+
+// ── DBus 获取 + JSON 解析 ──────────────────────────────────────────
+
+QList<RecentItem> RecentSearchStrategy::fetchRecentItems()
+{
+    QList<RecentItem> items;
+
+    QDBusInterface iface(QString::fromLatin1(kDBusService), QString::fromLatin1(kDBusPath),
+                         QString::fromLatin1(kDBusInterface),
+                         QDBusConnection::sessionBus());
+    if (!iface.isValid()) {
+        qWarning() << "RecentManager DBus interface is invalid:"
+                   << iface.lastError().message();
+        return items;
+    }
+
+    QDBusReply<QString> reply = iface.call(QString::fromLatin1(kDBusMethod));
+    if (!reply.isValid()) {
+        qWarning() << "RecentManager GetItemsInfo failed:" << reply.error().message();
+        return items;
+    }
+
+    const QByteArray raw = reply.value().toUtf8();
+    if (raw.isEmpty()) {
+        return items;
+    }
+
+    QJsonParseError parseErr;
+    const QJsonDocument doc = QJsonDocument::fromJson(raw, &parseErr);
+    if (parseErr.error != QJsonParseError::NoError || !doc.isArray()) {
+        qWarning() << "RecentManager: invalid JSON payload:" << parseErr.errorString();
+        return items;
+    }
+
+    const QJsonArray arr = doc.array();
+    items.reserve(arr.size());
+    for (const QJsonValue &v : arr) {
+        const QJsonObject obj = v.toObject();
+        RecentItem item;
+        item.href = obj.value("Href").toString();
+        item.path = obj.value("Path").toString();
+        item.modified = static_cast<qint64>(obj.value("modified").toVariant().toLongLong());
+        if (!item.path.isEmpty() && item.modified > 0) {
+            items.append(std::move(item));
+        }
+    }
+
+    return items;
+}
+
+// ── 过滤管道 ───────────────────────────────────────────────────────
+//
+// 三个 filterBy* 纯函数：输入 items + 约束 → 输出子集。
+// 行为与 FileNameRealTimeStrategy 中的对应过滤逻辑保持一致，
+// 确保语义搜索在不同数据源下产生可预期的匹配结果。
+
+QList<RecentItem> RecentSearchStrategy::filterByKeyword(const QList<RecentItem> &items,
+                                                         const QString &keyword) const
+{
+    if (keyword.isEmpty()) {
+        return items;
+    }
+
+    const bool caseSensitive = m_options.caseSensitive();
+    const Qt::CaseSensitivity cs = caseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive;
+
+    QList<RecentItem> out;
+    for (const RecentItem &item : items) {
+        const QString fileName = QFileInfo(item.path).fileName();
+        if (fileName.contains(keyword, cs)) {
+            out.append(item);
+        }
+    }
+    return out;
+}
+
+QList<RecentItem> RecentSearchStrategy::filterByExtensions(const QList<RecentItem> &items,
+                                                           const QStringList &extensions) const
+{
+    if (extensions.isEmpty()) {
+        return items;
+    }
+
+    QList<RecentItem> out;
+    for (const RecentItem &item : items) {
+        const QString suffix = QFileInfo(item.path).suffix().toLower();
+        if (extensions.contains(suffix)) {
+            out.append(item);
+        }
+    }
+    return out;
+}
+
+QList<RecentItem> RecentSearchStrategy::filterByTimeRange(const QList<RecentItem> &items) const
+{
+    const TimeRangeFilter filter = m_options.timeRangeFilter();
+    auto [start, end] = filter.resolveTimeRange();
+
+    QList<RecentItem> out;
+    for (const RecentItem &item : items) {
+        const QDateTime fileTime = QDateTime::fromSecsSinceEpoch(item.modified);
+
+        bool match = true;
+        if (start.isValid()) {
+            match = filter.includeLower() ? (fileTime >= start) : (fileTime > start);
+        }
+        if (match && end.isValid()) {
+            match = filter.includeUpper() ? (fileTime <= end) : (fileTime < end);
+        }
+        if (match) {
+            out.append(item);
+        }
+    }
+    return out;
+}
+
+// ── 结果构建 ───────────────────────────────────────────────────────
+
+SearchResult RecentSearchStrategy::toSearchResult(const RecentItem &item) const
+{
+    SearchResult result(item.path);
+    QFileInfo fi(item.path);
+
+    if (m_options.detailedResultsEnabled()) {
+        FileNameResultAPI api(result);
+        api.setIsDirectory(fi.isDir());
+        if (!fi.isDir()) {
+            api.setFileType(fi.suffix().isEmpty() ? QStringLiteral("unknown") : fi.suffix().toLower());
+            api.setFileExtension(fi.suffix().toLower());
+            api.setSize(QString::number(fi.size()));
+            api.setFileSizeBytes(fi.size());
+        } else {
+            api.setFileType(QStringLiteral("dir"));
+        }
+        api.setFilename(fi.fileName());
+        api.setIsHidden(fi.isHidden());
+        api.setModifyTimestamp(item.modified);   // 最近使用时间，非文件系统 mtime
+    }
+
+    return result;
+}
+
+// ── 主搜索流程 ─────────────────────────────────────────────────────
+
+void RecentSearchStrategy::search(const SearchQuery &query)
+{
+    m_cancelled.store(false);
+    m_results.clear();
+
+    QElapsedTimer timer;
+    timer.start();
+
+    // Step 1: 从 DBus 拉取全部最近使用记录
+    QList<RecentItem> items = fetchRecentItems();
+
+    if (m_cancelled.load()) {
+        emit searchFinished(m_results);
+        return;
+    }
+
+    // Step 2: 关键词过滤（仅 Simple 类型有 keyword；Boolean/Wildcard 暂不支持）
+    QString keyword;
+    if (query.type() == SearchQuery::Type::Simple) {
+        keyword = query.keyword();
+    } else if (query.type() == SearchQuery::Type::Boolean && !query.subQueries().isEmpty()) {
+        // 布尔查询取第一个子查询作为关键词（最近记录量小，不做全文布尔）
+        keyword = query.subQueries().first().keyword();
+    }
+    items = filterByKeyword(items, keyword);
+
+    // Step 3: 扩展名过滤
+    FileNameOptionsAPI optApi(const_cast<SearchOptions &>(m_options));
+    const QStringList exts = optApi.fileExtensions();
+    items = filterByExtensions(items, exts);
+
+    // Step 4: 时间范围过滤（基于 modified 时间戳）
+    if (m_options.hasTimeRangeFilter()) {
+        items = filterByTimeRange(items);
+    }
+
+    // Step 5: 构建 SearchResult 并发射
+    const bool resultFoundEnabled = m_options.resultFoundEnabled();
+    const int maxResults = m_options.maxResults() > 0 ? m_options.maxResults() : INT_MAX;
+
+    int count = 0;
+    for (const RecentItem &item : std::as_const(items)) {
+        if (m_cancelled.load() || count >= maxResults) {
+            break;
+        }
+
+        SearchResult result = toSearchResult(item);
+        m_results.append(result);
+        if (resultFoundEnabled) {
+            emit resultFound(result);
+        }
+        ++count;
+    }
+
+    qInfo() << "Recent search completed in" << timer.elapsed() << "ms with" << count << "results";
+    emit searchFinished(m_results);
+}
+
+void RecentSearchStrategy::cancel()
+{
+    m_cancelled.store(true);
+}
+
+DFM_SEARCH_END_NS

--- a/src/dfm-search/dfm-search-lib/recentsearch/recentstrategies/recentsearchstrategy.h
+++ b/src/dfm-search/dfm-search-lib/recentsearch/recentstrategies/recentsearchstrategy.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef RECENTSEARCHSTRATEGY_H
+#define RECENTSEARCHSTRATEGY_H
+
+#include "core/searchstrategy/basesearchstrategy.h"
+
+#include <dfm-search/filenamesearchapi.h>
+#include <dfm-search/timeresultapi.h>
+
+DFM_SEARCH_BEGIN_NS
+
+struct RecentItem {
+    QString path;   // 本地路径 (DBus "Path" 字段)
+    QString href;   // file:// URI (DBus "Href" 字段)
+    qint64 modified = 0;   // 最近访问时间戳，秒级 Unix epoch
+};
+
+/**
+ * @brief 搜索策略：从 DBus RecentManager 获取最近使用文件并过滤。
+ *
+ * 数据流：
+ *   1. 调用 org.deepin.Filemanager.Daemon.RecentManager.GetItemsInfo
+ *   2. 解析返回的 JSON 数组 → RecentItem 列表
+ *   3. 按 SearchQuery 关键词、SearchOptions 中的 fileExtensions + TimeRangeFilter 过滤
+ *   4. 发射 resultFound / searchFinished
+ *
+ * 时间过滤使用 RecentItem.modified 字段（最近访问时间），
+ * 而非文件系统的 lastModified——因为"最近使用"的语义是"上次打开时间"。
+ */
+class RecentSearchStrategy : public BaseSearchStrategy
+{
+    Q_OBJECT
+
+public:
+    explicit RecentSearchStrategy(const SearchOptions &options, QObject *parent = nullptr);
+    ~RecentSearchStrategy() override = default;
+
+    SearchType searchType() const override { return SearchType::Recent; }
+    void search(const SearchQuery &query) override;
+    void cancel() override;
+
+private:
+    // 调用 DBus 获取最近使用记录；失败时返回空列表并记录 warning。
+    QList<RecentItem> fetchRecentItems();
+
+    // ── 过滤管道（每个阶段纯函数，便于测试与组合） ──
+
+    /**
+     * @brief 按关键词过滤文件名。
+     *
+     * 关键词匹配 fileName() 而非完整 path——用户说"打开过的报告"时，
+     * "报告"应匹配文件名，不应匹配路径中的目录名。
+     * 空关键词时不过滤。
+     */
+    QList<RecentItem> filterByKeyword(const QList<RecentItem> &items, const QString &keyword) const;
+
+    /**
+     * @brief 按扩展名过滤。
+     * SearchOptions.fileExtensions 为小写后缀列表（如 ["pdf", "docx"]）。
+     * 空列表时不过滤。
+     */
+    QList<RecentItem> filterByExtensions(const QList<RecentItem> &items, const QStringList &extensions) const;
+
+    /**
+     * @brief 按 TimeRangeFilter 过滤 modified 时间戳。
+     *
+     * 注意：TimeRangeFilter.resolveTimeRange() 返回 QDateTime 对比，
+     * 但 RecentItem.modified 是秒级 epoch。需转 QDateTime 比较。
+     * start/end 无效时不约束该侧。
+     */
+    QList<RecentItem> filterByTimeRange(const QList<RecentItem> &items) const;
+
+    /**
+     * @brief 将 RecentItem 转换为 SearchResult，填充详细属性。
+     */
+    SearchResult toSearchResult(const RecentItem &item) const;
+};
+
+DFM_SEARCH_END_NS
+
+#endif   // RECENTSEARCHSTRATEGY_H

--- a/src/dfm-search/dfm-search-lib/semantic/extractors/actionextractor.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/extractors/actionextractor.cpp
@@ -39,6 +39,21 @@ void ActionExtractor::extract(const QString &input, ParsedIntent &intent)
         const QString imCategory = metadata.value("im_category").toString();
         const bool includeHidden = metadata.value("include_hidden", false).toBool();
         const bool hiddenOnly = metadata.value("hidden_only", false).toBool();
+        const bool recent = metadata.value("recent", false).toBool();
+
+        // ── Recently-used files (DBus RecentManager data source) ──
+        if (recent) {
+            intent.setRecentOnly(true);
+            // Force ModifyTime — recent records only carry a "modified" timestamp
+            intent.timeConstraint().setTimeField(TimeField::ModifyTime);
+
+            MatchSpan span;
+            span.setStart(m.capturedStart());
+            span.setEnd(m.capturedEnd());
+            span.setRuleId(ruleIds[i]);
+            intent.consumedSpans().append(span);
+            continue;
+        }
 
         // ── Hidden-only files (filename search only, include hidden directories) ──
         if (hiddenOnly) {

--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/action_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/action_rules.json
@@ -45,6 +45,16 @@
                     "metadata": {
                         "im_category": "received"
                     }
+                },
+                {
+                    "id": "action_recent",
+                    "pattern": "打开过的|看过的|浏览过的|读过的|点开过的",
+                    "description": "Action: recently used files — sourced from RecentManager DBus (XDG recent records)",
+                    "enabled": true,
+                    "priority": 180,
+                    "metadata": {
+                        "recent": true
+                    }
                 }
             ]
         }

--- a/src/dfm-search/dfm-search-lib/semantic/semanticquerybuilder.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/semanticquerybuilder.cpp
@@ -23,11 +23,36 @@ SemanticSearchPlan SemanticQueryBuilder::build(const ParsedIntent &intent)
     plan.searchDirectories = intent.searchDirectories();
     plan.includeHidden = intent.includeHidden() || intent.hiddenOnly();
     plan.hiddenOnly = intent.hiddenOnly();
+    plan.recentOnly = intent.recentOnly();
 
     // When hiddenOnly is true, force filename-only search (no content/OCR)
     const SearchTarget effectiveTarget = intent.hiddenOnly()
             ? SearchTarget::FileNameOnly
             : intent.searchTarget();
+
+    // ── Recently-used files: route to RecentSearchEngine (DBus data source) ──
+    // 最近使用记录不在 lucene++ 索引中，因此当 recentOnly 为 true 时，
+    // 抑制所有 index-based 引擎，仅启动 Recent 引擎。
+    if (plan.recentOnly) {
+        plan.recentOptions = buildBaseOptions(intent.timeConstraint(), intent.sizeConstraint());
+        // Recent 引擎不依赖 SearchMethod::Indexed，但保留 options 一致性
+        plan.recentOptions->setSearchMethod(SearchMethod::Realtime);
+
+        FileNameOptionsAPI recentApi(*plan.recentOptions);
+        if (!intent.fileExtensions().isEmpty()) {
+            recentApi.setFileExtensions(intent.fileExtensions());
+        }
+
+        if (intent.keywords().size() == 1) {
+            plan.recentQuery = SearchFactory::createQuery(intent.keywords().first());
+        } else if (intent.keywords().size() > 1) {
+            plan.recentQuery = SearchFactory::createQuery(intent.keywords(), SearchQuery::Type::Boolean);
+        } else {
+            plan.recentQuery = SearchFactory::createQuery(QStringLiteral(""));
+        }
+
+        return plan;   // recentOnly 独占搜索路径，不启动其他引擎
+    }
 
     // Determine time field strategy
     if (intent.timeConstraint().isValid() && intent.timeConstraint().timeField() == TimeField::Unspecified) {

--- a/src/dfm-search/dfm-search-lib/semantic/semanticquerybuilder.h
+++ b/src/dfm-search/dfm-search-lib/semantic/semanticquerybuilder.h
@@ -24,10 +24,13 @@ struct SemanticSearchPlan {
     std::optional<SearchOptions> contentOptions;
     std::optional<SearchQuery> ocrQuery;
     std::optional<SearchOptions> ocrOptions;
+    std::optional<SearchQuery> recentQuery;   // 最近使用文件搜索 (DBus 数据源)
+    std::optional<SearchOptions> recentOptions;
     TimeField timeField = TimeField::ModifyTime;   // BirthTime, ModifyTime, or Both
     QStringList searchDirectories;   // Empty = use default homePath
     bool includeHidden = false;      // For trash directory
     bool hiddenOnly = false;         // true = only return hidden files (filename only)
+    bool recentOnly = false;         // true = search recently-used files only (suppress index engines)
 };
 
 /**

--- a/src/dfm-search/dfm-search-lib/semantic/semanticsearcher.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/semanticsearcher.cpp
@@ -153,33 +153,44 @@ void SemanticSearcherData::doSearch(const QString &naturalLanguage, const QStrin
         }
     };
 
-    // Step 8: Launch up to 3 engines (FileName, Content, OCR)
+    // Step 8: Launch engines based on plan
     // TimeField::Both is no longer expanded here; it is handled by the Lucene strategy layer.
     // Multiple directories are passed via setSearchPaths().
 
-    // File name search (always, if index is ready)
-    if (Global::isFileNameIndexReadyForSearch()) {
-        SearchOptions fnameOpts = prepareOptions(plan.fileNameOptions);
-        applyCallerOptions(fnameOpts);
-        createAndLaunchEngine(SearchType::FileName, plan.fileNameQuery,
-                              fnameOpts, onFinished, onError);
-    }
+    // ── Recently-used files: DBus data source, exclusive path ──
+    // recentOnly 抑制所有 index-based 引擎（数据不在索引中）。
+    if (plan.recentOnly && plan.recentQuery.has_value() && plan.recentOptions.has_value()) {
+        SearchOptions recentOpts = *plan.recentOptions;
+        applyCallerOptions(recentOpts);
+        createAndLaunchEngine(SearchType::Recent, *plan.recentQuery,
+                              recentOpts, onFinished, onError);
+    } else {
+        // ── Index-based engines: FileName, Content, OCR ──
 
-    // Content search
-    if (plan.contentQuery.has_value() && plan.contentOptions.has_value()) {
-        SearchOptions contentOpts = prepareOptions(*plan.contentOptions);
-        applyCallerOptions(contentOpts);
-        createAndLaunchEngine(SearchType::Content, *plan.contentQuery,
-                              contentOpts, onFinished, onError);
-    }
+        // File name search (always, if index is ready)
+        if (Global::isFileNameIndexReadyForSearch()) {
+            SearchOptions fnameOpts = prepareOptions(plan.fileNameOptions);
+            applyCallerOptions(fnameOpts);
+            createAndLaunchEngine(SearchType::FileName, plan.fileNameQuery,
+                                  fnameOpts, onFinished, onError);
+        }
 
-    // OCR search
-    if (plan.ocrQuery.has_value() && plan.ocrOptions.has_value()) {
-        SearchOptions ocrOpts = prepareOptions(*plan.ocrOptions);
-        applyCallerOptions(ocrOpts);
-        createAndLaunchEngine(SearchType::Ocr, *plan.ocrQuery,
-                              ocrOpts, onFinished, onError);
-    }
+        // Content search
+        if (plan.contentQuery.has_value() && plan.contentOptions.has_value()) {
+            SearchOptions contentOpts = prepareOptions(*plan.contentOptions);
+            applyCallerOptions(contentOpts);
+            createAndLaunchEngine(SearchType::Content, *plan.contentQuery,
+                                  contentOpts, onFinished, onError);
+        }
+
+        // OCR search
+        if (plan.ocrQuery.has_value() && plan.ocrOptions.has_value()) {
+            SearchOptions ocrOpts = prepareOptions(*plan.ocrOptions);
+            applyCallerOptions(ocrOpts);
+            createAndLaunchEngine(SearchType::Ocr, *plan.ocrQuery,
+                                  ocrOpts, onFinished, onError);
+        }
+    }   // end of else (index-based engines)
 
     // Step 9: Handle no-engine case
     if (pendingFinishCount.load() == 0) {
@@ -292,6 +303,7 @@ bool SemanticSearcher::isSemanticQuery(const QString &input) const
             || !intent.searchDirectories().isEmpty()
             || intent.includeHidden()
             || intent.hiddenOnly()
+            || intent.recentOnly()
             || !intent.consumedSpans().isEmpty();
 }
 

--- a/src/dfm-search/dfm-search-lib/utils/parsedintent.cpp
+++ b/src/dfm-search/dfm-search-lib/utils/parsedintent.cpp
@@ -113,6 +113,17 @@ void ParsedIntent::setHiddenOnly(bool hidden)
     d->hiddenOnly = hidden;
 }
 
+// recentOnly
+bool ParsedIntent::recentOnly() const
+{
+    return d->recentOnly;
+}
+
+void ParsedIntent::setRecentOnly(bool recent)
+{
+    d->recentOnly = recent;
+}
+
 // keywords
 const QStringList &ParsedIntent::keywords() const
 {

--- a/src/dfm-search/dfm-search-lib/utils/parsedintent_p.h
+++ b/src/dfm-search/dfm-search-lib/utils/parsedintent_p.h
@@ -24,6 +24,7 @@ public:
     QStringList searchDirectories;
     bool includeHidden = false;
     bool hiddenOnly = false;
+    bool recentOnly = false;   // true = search recently-used files (DBus RecentManager)
     QStringList keywords;
     SearchTarget searchTarget = SearchTarget::All;
     QList<MatchSpan> consumedSpans;


### PR DESCRIPTION
Added support for searching recently-used files through DBus
RecentManager interface.
This involves a new SearchType::Recent enum value and a dedicated
RecentSearchEngine.
The feature is triggered by natural language patterns like "看过的" or
"打开过的".

Key changes:
1. Added RecentSearchEngine and related DBus integration
2. Implemented search strategy with keyword, extension, and time
filtering
3. Added new semantic rules for Chinese NLP to trigger recent searches
4. Extended ParsedIntent to include recentOnly flag
5. Updated semantic query building and execution logic to handle recent
searches

Log: Added recent files search functionality via DBus RecentManager

Influence:
1. Test Chinese NLP patterns like "打开过的文件" and "看过的pdf"
2. Verify time constraints work with recent items
3. Test keyword and extension filtering
4. Verify bare verbs like "打开文件" don't trigger recent search
5. Check that recentOnly properly suppresses index-based searches
6. Test DBus error handling and fallback behavior

feat: 通过DBus RecentManager实现最近文件搜索功能

新增通过DBus RecentManager接口搜索最近使用文件的支持。
包括新的SearchType::Recent枚举值和专用的RecentSearchEngine。
该功能通过"看过的"、"打开过的"等自然语言模式触发。

主要变更：
1. 新增RecentSearchEngine及相关DBus集成
2. 实现带关键词、扩展名和时间过滤的搜索策略
3. 为中文NLP添加新的语义规则以触发最近文件搜索
4. 扩展ParsedIntent包含recentOnly标志
5. 更新语义查询构建和执行逻辑以处理最近文件搜索

Log: 新增通过DBus RecentManager搜索最近文件的功能

影响范围：
1. 测试中文NLP模式如"打开过的文件"和"看过的pdf"
2. 验证时间约束条件与最近文件的交互
3. 测试关键词和扩展名过滤功能
4. 验证"打开文件"等简单动词不会误触发最近文件搜索
5. 检查recentOnly正确抑制基于索引的搜索
6. 测试DBus错误处理和回退行为
