### PR TITLE
semantic search

### DIFF
--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -95,6 +95,18 @@ bool DEnumeratorPrivate::createEnumerator(const QUrl &url, QPointer<DEnumeratorP
                                                              enumLinks ? G_FILE_QUERY_INFO_NONE : G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
                                                              cancellable,
                                                              &gerror);
+
+    // g_file_enumerate_children internally creates and destroys temporary
+    // GDBusProxy instances (mount tracker proxy, daemon proxy).  During proxy
+    // finalization, g_dbus_connection_signal_unsubscribe defers the
+    // user_data_free_func (weak_ref_free) to the thread-default GMainContext
+    // via call_destroy_notify() — a g_idle_source.  Process it now while we
+    // are on the same thread, otherwise the GWeakRef (8 bytes from
+    // gdbusproxy.c:112) leaks when no GLib main loop runs on this QThread.
+    // See: glib2.0/gio/gdbusconnection.c:signal_subscriber_unref → call_destroy_notify
+    GMainContext *ctx = g_main_context_get_thread_default();
+    if (ctx)
+        g_main_context_iteration(ctx, TRUE);
     if (!me) {
         // Clean up the enumerator if it was created but the object is no longer valid
         if (genumerator) {

--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -41,6 +41,10 @@ DEnumeratorPrivate::~DEnumeratorPrivate()
         g_object_unref(cancellable);
         cancellable = nullptr;
     }
+    if (fts) {
+        fts_close(fts);
+        fts = nullptr;
+    }
 }
 
 bool DEnumeratorPrivate::init(const QUrl &url)

--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -462,12 +462,29 @@ char *DEnumeratorPrivate::filePath(const QUrl &url)
 
 QUrl DEnumeratorPrivate::buildUrl(const QUrl &url, const char *fileName)
 {
-    QString path;
-    if (url.path() == "/") {
-        path = "/" + QString(fileName);
+    // 防御空指针，避免std::string或QByteArray构造时崩溃
+    if (!fileName) {
+        return QUrl();
+    }
+
+    // 拦截路径遍历攻击，防止恶意文件名越权
+    QByteArray fileNameBa(fileName);
+    if (fileNameBa.contains('/') || fileNameBa.contains('\\') || fileNameBa == "." || fileNameBa == "..") {
+        return QUrl();
+    }
+
+    QByteArray path;
+    QString urlPath = url.path();
+
+    if (urlPath == "/" || urlPath.isEmpty()) {
+        path = QByteArray("/") + fileNameBa;
     } else {
-        QString dirPath = url.path();
-        path = dirPath.endsWith('/') ? dirPath + QString(fileName) : dirPath + "/" + QString(fileName);
+        QByteArray dirPath = urlPath.toUtf8();
+        if (!dirPath.endsWith('/')) {
+            dirPath.append('/');
+        }
+        // 使用QByteArray进行底层字节数组拼接，避免QString剥离BOM (efbbbf)
+        path = dirPath + fileNameBa;
     }
 
     // 保留原始 URL 的 scheme 和 host，而不是假定为本地文件

--- a/src/dfm-io/dfm-io/dfileinfo.cpp
+++ b/src/dfm-io/dfm-io/dfileinfo.cpp
@@ -15,7 +15,6 @@
 #include <QDebug>
 #include <QThread>
 
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <execinfo.h>
 
@@ -281,6 +280,24 @@ void DFileInfoPrivate::queryInfoAsync(int ioPriority, DFileInfo::InitQuerierAsyn
     g_file_query_info_async(this->gfile, attributes, GFileQueryInfoFlags(flag), ioPriority, gcancellable, queryInfoAsyncCallback, dataOp);
 }
 
+bool DFileInfoPrivate::ensureStatxCached() const
+{
+    if (statxCached)
+        return statxValid;
+
+    statxCached = true;
+
+    const QUrl &url = q->uri();
+    if (!url.isLocalFile())
+        return false;
+
+    unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
+    int ret = statx(AT_FDCWD, url.path().toStdString().data(),
+                    AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuf);
+    statxValid = (ret == 0);
+    return statxValid;
+}
+
 QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
 {
     QVariant retValue;
@@ -295,16 +312,10 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             return QVariant();
         uint64_t ret = g_file_info_get_attribute_uint64(gfileinfo, key.c_str());
         if (ret == 0) {
-            struct statx statxBuffer;
-            unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
-            const QUrl &url = q->uri();
-            if (!url.isLocalFile())
-                return QVariant();
-            int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret != 0)
+            if (!ensureStatxCached())
                 return QVariant();
 
-            return quint64(statxBuffer.stx_btime.tv_sec);
+            return quint64(statxBuf.stx_btime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -314,16 +325,10 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             return QVariant();
         uint32_t ret = g_file_info_get_attribute_uint32(gfileinfo, key.c_str());
         if (ret == 0) {
-            struct statx statxBuffer;
-            unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
-            const QUrl &url = q->uri();
-            if (!url.isLocalFile())
-                return QVariant();
-            int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret != 0)
+            if (!ensureStatxCached())
                 return QVariant();
 
-            return statxBuffer.stx_btime.tv_nsec / 1000000;
+            return statxBuf.stx_btime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }
@@ -333,16 +338,10 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             return QVariant();
         uint64_t ret = g_file_info_get_attribute_uint64(gfileinfo, key.c_str());
         if (ret == 0) {
-            struct statx statxBuffer;
-            unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
-            const QUrl &url = q->uri();
-            if (!url.isLocalFile())
-                return QVariant();
-            int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret != 0)
+            if (!ensureStatxCached())
                 return QVariant();
 
-            return quint64(statxBuffer.stx_mtime.tv_sec);
+            return quint64(statxBuf.stx_mtime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -352,16 +351,10 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             return QVariant();
         uint32_t ret = g_file_info_get_attribute_uint32(gfileinfo, key.c_str());
         if (ret == 0) {
-            struct statx statxBuffer;
-            unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
-            const QUrl &url = q->uri();
-            if (!url.isLocalFile())
-                return QVariant();
-            int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret != 0)
+            if (!ensureStatxCached())
                 return QVariant();
 
-            return statxBuffer.stx_mtime.tv_nsec / 1000000;
+            return statxBuf.stx_mtime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }
@@ -371,16 +364,10 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             return QVariant();
         uint64_t ret = g_file_info_get_attribute_uint64(gfileinfo, key.c_str());
         if (ret == 0) {
-            struct statx statxBuffer;
-            unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
-            const QUrl &url = q->uri();
-            if (!url.isLocalFile())
-                return QVariant();
-            int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret != 0)
+            if (!ensureStatxCached())
                 return QVariant();
 
-            return quint64(statxBuffer.stx_atime.tv_sec);
+            return quint64(statxBuf.stx_atime.tv_sec);
         }
         return qulonglong(ret);
     }
@@ -390,16 +377,10 @@ QVariant DFileInfoPrivate::attributesBySelf(DFileInfo::AttributeID id)
             return QVariant();
         uint32_t ret = g_file_info_get_attribute_uint32(gfileinfo, key.c_str());
         if (ret == 0) {
-            struct statx statxBuffer;
-            unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
-            const QUrl &url = q->uri();
-            if (!url.isLocalFile())
-                return QVariant();
-            int ret = statx(AT_FDCWD, url.path().toStdString().data(), AT_SYMLINK_NOFOLLOW | AT_NO_AUTOMOUNT, mask, &statxBuffer);
-            if (ret != 0)
+            if (!ensureStatxCached())
                 return QVariant();
 
-            return statxBuffer.stx_atime.tv_nsec / 1000000;
+            return statxBuf.stx_atime.tv_nsec / 1000000;
         }
         return QVariant(ret);
     }

--- a/src/dfm-io/dfm-io/private/dfileinfo_p.h
+++ b/src/dfm-io/dfm-io/private/dfileinfo_p.h
@@ -19,6 +19,7 @@
 
 #include <unordered_map>
 #include <string>
+#include <sys/stat.h>
 
 BEGIN_IO_NAMESPACE
 
@@ -55,6 +56,7 @@ public:
     QVariant attributesBySelf(DFileInfo::AttributeID id);
     QVariant attributesFromUrl(DFileInfo::AttributeID id);
     void checkAndResetCancel();
+    [[nodiscard]] bool ensureStatxCached() const;
 
     [[nodiscard]] DFileFuture *initQuerierAsync(int ioPriority, QObject *parent = nullptr) const;
     [[nodiscard]] QFuture<void> refreshAsync();
@@ -94,6 +96,11 @@ public:
     std::atomic_bool stoped { false };
     std::atomic_bool fileExists { false };
     QMap<DFileInfo::AttributeID, QVariant> caches;
+
+    // statx 缓存：6 个时间属性 case 共享一次 statx 调用，避免重复系统调用
+    mutable struct statx statxBuf {};
+    mutable bool statxCached { false };
+    mutable bool statxValid { false };
     std::atomic_bool cacheing { false };
     std::atomic_bool refreshing { false };
     QMutex mutex;


### PR DESCRIPTION
- **fix(dfm-io): drain GLib deferred callbacks after g_file_enumerate_children**
- **fix(dfm-io): close FTS tree in destructor to prevent memory leak**
- **perf(dfm-io): cache statx results in DFileInfoPrivate::attributesBySelf**
- **fix: prevent BOM character loss in path concatenation**
