### PR TITLE
refactor: update recent search D-Bus integration

### DIFF
--- a/src/dfm-search/dfm-search-lib/recentsearch/recentstrategies/recentsearchstrategy.cpp
+++ b/src/dfm-search/dfm-search-lib/recentsearch/recentstrategies/recentsearchstrategy.cpp
@@ -18,7 +18,7 @@
 DFM_SEARCH_BEGIN_NS
 
 namespace {
-constexpr auto kDBusService = "org.deepin.Filemanager.Daemon.RecentManager";
+constexpr auto kDBusService = "org.deepin.Filemanager.Daemon";
 constexpr auto kDBusPath = "/org/deepin/Filemanager/Daemon/RecentManager";
 constexpr auto kDBusInterface = "org.deepin.Filemanager.Daemon.RecentManager";
 constexpr auto kDBusMethod = "GetItemsInfo";
@@ -44,34 +44,26 @@ QList<RecentItem> RecentSearchStrategy::fetchRecentItems()
         return items;
     }
 
-    QDBusReply<QString> reply = iface.call(QString::fromLatin1(kDBusMethod));
+    QDBusPendingReply<QVariantList> reply = iface.call(QString::fromLatin1(kDBusMethod));
     if (!reply.isValid()) {
         qWarning() << "RecentManager GetItemsInfo failed:" << reply.error().message();
         return items;
     }
+    const QVariantList &topLevelList = reply.value();
 
-    const QByteArray raw = reply.value().toUtf8();
-    if (raw.isEmpty()) {
-        return items;
-    }
+    for (const auto &v : topLevelList) {
+        QDBusArgument dbusArg = v.value<QDBusArgument>();
 
-    QJsonParseError parseErr;
-    const QJsonDocument doc = QJsonDocument::fromJson(raw, &parseErr);
-    if (parseErr.error != QJsonParseError::NoError || !doc.isArray()) {
-        qWarning() << "RecentManager: invalid JSON payload:" << parseErr.errorString();
-        return items;
-    }
-
-    const QJsonArray arr = doc.array();
-    items.reserve(arr.size());
-    for (const QJsonValue &v : arr) {
-        const QJsonObject obj = v.toObject();
-        RecentItem item;
-        item.href = obj.value("Href").toString();
-        item.path = obj.value("Path").toString();
-        item.modified = static_cast<qint64>(obj.value("modified").toVariant().toLongLong());
-        if (!item.path.isEmpty() && item.modified > 0) {
-            items.append(std::move(item));
+        QVariantMap map;
+        dbusArg >> map;   // 直接将QDBusArgument解包为QVariantMap
+        if (!map.isEmpty()) {
+            RecentItem item;
+            item.href = map.value("Href").toString();
+            item.path = map.value("Path").toString();
+            item.modified = static_cast<qint64>(map.value("modified").toLongLong());
+            if (!item.path.isEmpty() && item.modified > 0) {
+                items.append(std::move(item));
+            }
         }
     }
 
@@ -85,7 +77,7 @@ QList<RecentItem> RecentSearchStrategy::fetchRecentItems()
 // 确保语义搜索在不同数据源下产生可预期的匹配结果。
 
 QList<RecentItem> RecentSearchStrategy::filterByKeyword(const QList<RecentItem> &items,
-                                                         const QString &keyword) const
+                                                        const QString &keyword) const
 {
     if (keyword.isEmpty()) {
         return items;

--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/action_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/action_rules.json
@@ -48,7 +48,7 @@
                 },
                 {
                     "id": "action_recent",
-                    "pattern": "打开过的|看过的|浏览过的|读过的|点开过的",
+                    "pattern": "打开的|打开过的|看过的|浏览过的|读过的|点开过的",
                     "description": "Action: recently used files — sourced from RecentManager DBus (XDG recent records)",
                     "enabled": true,
                     "priority": 180,


### PR DESCRIPTION
1. Changed D-Bus service name to use the common FileManager daemon
service
2. Modified the D-Bus call to use QDBusPendingReply<QVariantList>
instead of handling raw JSON
3. Simplified the data parsing by using QDBusArgument direct conversion
to QVariantMap
4. Fixed code indentation in filterByKeyword method parameters
5. Removed unnecessary JSON parsing logic since D-Bus now returns
structured data directly

The changes improve the reliability and performance of recent items
retrieval by:
1. Using the correct standard D-Bus service name
2. Eliminating the JSON serialization/deserialization overhead
3. Making the code more maintainable with direct D-Bus type conversion
4. Following better D-Bus integration practices

Influence:
1. Verify recent items are still correctly retrieved and displayed
2. Test search functionality with different keywords
3. Check filterByKeyword method works as expected
4. Ensure there are no D-Bus related errors in logs
5. Test with various recent file scenarios (empty list, single item,
multiple items)

refactor: 更新最近搜索的 D-Bus 集成

1. 将 D-Bus 服务名称改为使用通用的文件管理器守护进程服务
2. 修改 D-Bus 调用改用 QDBusPendingReply<QVariantList> 而非处理原始 JSON
3. 通过直接使用 QDBusArgument 转换到 QVariantMap 简化了数据解析
4. 修复了 filterByKeyword 方法参数中的代码缩进
5. 移除了不必要的 JSON 解析逻辑，因为 D-Bus 现在直接返回结构化数据

这些改进通过以下方式提升了最近项检索的可靠性和性能：
1. 使用正确的标准 D-Bus 服务名称
2. 消除了 JSON 序列化/反序列化的开销
3. 通过直接的 D-Bus 类型转换使代码更易维护
4. 遵循更好的 D-Bus 集成实践

Influence:
1. 验证最近项目是否正确检索和显示
2. 使用不同关键词测试搜索功能
3. 检查 filterByKeyword 方法是否按预期工作
4. 确保日志中没有 D-Bus 相关错误
5. 测试各种最近文件场景(空列表、单个项目、多个项目)
