### PR TITLE
fix: adjust search directory priority in semantic search

### DIFF
--- a/src/dfm-search/dfm-search-lib/semantic/semanticsearcher.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/semanticsearcher.cpp
@@ -76,12 +76,14 @@ void SemanticSearcherData::doSearch(const QString &naturalLanguage, const QStrin
     const SemanticSearchPlan plan = queryBuilder->build(intent);
 
     // Step 4: Determine search directories
-    // Priority: caller-specified directories > NLP-parsed directories > home directory
+    // Priority: NLP-parsed directories > caller-specified directories > home directory
+    // NLP 解析出的路径是用户意图的最直接表达（如"在文档里找xxx"），
+    // 应优先于调用者传入的默认路径。
     QStringList dirs;
-    if (!searchDirectories.isEmpty()) {
-        dirs = searchDirectories;
-    } else if (!plan.searchDirectories.isEmpty()) {
+    if (!plan.searchDirectories.isEmpty()) {
         dirs = plan.searchDirectories;
+    } else if (!searchDirectories.isEmpty()) {
+        dirs = searchDirectories;
     } else {
         dirs = QStringList { QDir::homePath() };
     }


### PR DESCRIPTION
Modified the search directory priority logic in semantic search to
prioritize NLP-parsed directories over caller-specified ones. This
change better reflects user intent when they specify locations in
natural language queries (e.g. "search in documents").

The previous implementation gave higher priority to caller-specified
directories, which could override the user's explicit intent from
their natural language query. For example, if a user searches "find
xxx in documents" while the application provides Downloads as default
directory, we should search in Documents first.

Log:
Fixed semantic search to properly prioritize user-specified locations
from natural language queries over default directories

Influence:
1. Test searches with locations specified in natural language (e.g.
"find in documents")
2. Verify behavior when both natural language locations and caller
defaults exist
3. Check home directory fallback when no locations specified
4. Test various combinations of natural language inputs and default
directories

fix: 调整语义搜索中目录优先级

修改了语义搜索中目录优先级逻辑，将NLP解析出的目录优先于调用者指定的目
录。这一改动更好地反映了用户在自然语言查询中指定位置时的意图（例如"在文
档里找xxx"）。

之前的实现将调用者指定的目录设为更高优先级，可能会覆盖用户在自然语言查询
中明确表达的意图。例如，当用户搜索"在文档里找xxx"而应用程序默认在下载目
录搜索时，我们应该优先在文档目录搜索。

Log:
修复语义搜索功能，使其正确优先处理自然语言查询中用户指定的位置而非默认
目录

Influence:
1. 测试包含自然语言位置指定的搜索（如"在文档中查找"）
2. 验证当自然语言位置和调用者默认目录同时存在时的行为
3. 检查未指定位置时回退到主目录的情况
4. 测试各种自然语言输入和默认目录的组合

## Summary by Sourcery

Bug Fixes:
- Ensure semantic search respects user-specified locations extracted from natural language queries ahead of default directories.