### PR TITLE
semantic search

### DIFF
--- a/include/dfm-search/dfm-search/semanticsearcher.h
+++ b/include/dfm-search/dfm-search/semanticsearcher.h
@@ -85,10 +85,36 @@ public:
     void search(const QString &naturalLanguage, const QStringList &searchDirectories);
 
     /**
+     * @brief Parse natural language input into a structured intent.
+     *
+     * Synchronously runs the full dimension extractor pipeline (time, size,
+     * file type, action, location, keyword) and returns the result. Does NOT
+     * start any search. Use this when you need to inspect what the NLP parser
+     * understood without triggering a search — e.g., for intent preview UIs,
+     * debugging, or composing custom search plans.
+     *
+     * Equivalent to the parsing performed internally by search() before
+     * searchStarted fires; the same ParsedIntent is emitted via intentParsed().
+     *
+     * @param input The natural language query string
+     * @return The parsed intent. If parsing yields no constraints, the returned
+     *         ParsedIntent has an invalid timeConstraint, invalid sizeConstraint,
+     *         empty fileExtensions, empty searchDirectories, and empty consumedSpans.
+     *
+     * @see isSemanticQuery() for a boolean check built on top of this method.
+     */
+    ParsedIntent parseIntent(const QString &input) const;
+
+    /**
      * @brief Check if the input contains semantic intent beyond a plain keyword.
      *
      * Returns true if parsing the input reveals time constraints, size constraints,
      * file type filters, or location constraints. Returns false for plain keyword input.
+     *
+     * This is a convenience wrapper around parseIntent(): it parses once and
+     * checks whether any semantic dimension was extracted. The parsing result
+     * is discarded; if you need the parsed intent, call parseIntent() directly
+     * to avoid parsing twice.
      *
      * This allows callers to avoid unnecessary semantic search overhead when
      * the user is just typing a simple keyword.

--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/filetype_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/filetype_rules.json
@@ -55,7 +55,7 @@
                     "enabled": true,
                     "priority": 100,
                     "metadata": {
-                        "extensions": ["doc", "docx", "pdf", "txt", "wps", "rtf", "md", "odt"],
+                        "extensions": ["rtf","odt","ods","odp","odg","docx","xlsx","et","pptx","ppsx","md","xls","xlsb","doc","dot","wps","ppt","pps","txt","pdf","dps","sh","json","yaml","ini","bat","sql","uof","ofd","pot"],
                         "fileTypes": ["doc"],
                         "general": true
                     }

--- a/src/dfm-search/dfm-search-lib/semantic/semanticsearcher.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/semanticsearcher.cpp
@@ -290,14 +290,20 @@ void SemanticSearcher::search(const QString &naturalLanguage, const QStringList 
     d_ptr->doSearch(naturalLanguage, searchDirectories);
 }
 
-bool SemanticSearcher::isSemanticQuery(const QString &input) const
+ParsedIntent SemanticSearcher::parseIntent(const QString &input) const
 {
+    ParsedIntent intent;
     if (input.trimmed().isEmpty()) {
-        return false;
+        return intent;   // default-constructed: all constraints invalid/empty
     }
 
-    ParsedIntent intent;
     d_ptr->intentParser->parse(input, intent);
+    return intent;
+}
+
+bool SemanticSearcher::isSemanticQuery(const QString &input) const
+{
+    const ParsedIntent intent = parseIntent(input);
 
     return intent.timeConstraint().isValid()
             || intent.sizeConstraint().isValid()


### PR DESCRIPTION
- **feat: add parseIntent API for semantic search preview**
- **feat: expand supported document file extensions**

## Summary by Sourcery

Introduce a public intent parsing API for semantic search and reuse it for semantic query detection while expanding supported file type rules.

New Features:
- Add a parseIntent API to expose structured semantic intent parsing without starting a search.

Enhancements:
- Refactor isSemanticQuery to reuse the shared intent parsing pipeline instead of duplicating parsing logic.
- Extend semantic search file type rules to cover additional document extensions.