### PR TITLE
fix: handle hidden files search without keywords

### DIFF
--- a/autotests/dfm-search-tests/tst_semantic_search.cpp
+++ b/autotests/dfm-search-tests/tst_semantic_search.cpp
@@ -1300,6 +1300,7 @@ private Q_SLOTS:
     void defaultTarget();
     void fileNameOnlyTarget();
     void contentOnlyTarget();
+    void hiddenOnlyNoKeyword();
 
 private:
     ParsedIntent makeIntent(const QStringList &keywords, SearchTarget target) const;
@@ -1348,6 +1349,36 @@ void tst_SemanticQueryBuilderTarget::contentOnlyTarget()
     QVERIFY(plan.fileNameQuery.keyword().isEmpty());
     QVERIFY(plan.contentQuery.has_value());
     QVERIFY(plan.ocrQuery.has_value());
+}
+
+void tst_SemanticQueryBuilderTarget::hiddenOnlyNoKeyword()
+{
+    // "下载的隐藏文件" 这类仅含位置槽 + 属性槽、无关键字槽的语义搜索：
+    // 解析后 hiddenOnly=true、includeHidden=true、searchTarget=FileNameOnly、keywords=[]。
+    // 预期 plan 仍应构建 fileName 路径（空关键字），由 indexedstrategy 的
+    // hiddenOnlyQuery (kIsHidden:Y) 作为主查询条件，pathPrefixQuery 限制到下载目录。
+    SemanticQueryBuilder builder;
+    ParsedIntent intent;
+    intent.setKeywords({});                  // 无关键字
+    intent.setHiddenOnly(true);
+    intent.setIncludeHidden(true);
+    intent.setSearchTarget(SearchTarget::FileNameOnly);
+    intent.setSearchDirectories({ QStringLiteral("/home/test/Downloads") });
+
+    SemanticSearchPlan plan = builder.build(intent);
+
+    // plan 顶层标志必须正确（SemanticSearcher.prepareOptions 会据此透传到 SearchOptions）
+    QVERIFY(plan.hiddenOnly);
+    QVERIFY(plan.includeHidden);
+    QVERIFY(plan.searchDirectories == QStringList { QStringLiteral("/home/test/Downloads") });
+
+    // fileName 路径必须构建（即使关键字为空）—— 否则搜索根本不会执行
+    // indexedstrategy 依赖空关键字的 fileNameQuery 走 Simple 分支，由 hiddenOnlyQuery 兜底
+    QVERIFY(plan.fileNameQuery.keyword().isEmpty());
+
+    // content/ocr 不应启用（hiddenOnly 强制 FileNameOnly，且无关键字）
+    QVERIFY(!plan.contentQuery.has_value());
+    QVERIFY(!plan.ocrQuery.has_value());
 }
 
 // ===== Factory functions =====

--- a/src/dfm-search/dfm-search-lib/filenamesearch/filenamesearchengine.cpp
+++ b/src/dfm-search/dfm-search-lib/filenamesearch/filenamesearchengine.cpp
@@ -56,9 +56,11 @@ SearchError FileNameSearchEngine::validateSearchConditions()
     // 文件名搜索特定验证
     if (m_currentQuery.type() == SearchQuery::Type::Simple
         || m_currentQuery.type() == SearchQuery::Type::Wildcard) {
-        // 允许对类型/后缀/大小范围/时间范围进行搜索，获取满足条件的所有文件
+        // 允许对类型/后缀/大小范围/时间范围/隐藏文件进行搜索，获取满足条件的所有文件
+        // hiddenOnly=true 时（如"下载的隐藏文件"），无需关键字，按 kIsHidden:Y 过滤即可
         if (m_currentQuery.keyword().isEmpty() && fileTypes.isEmpty() && fileExts.isEmpty()
-            && !m_options.hasSizeRangeFilter() && !m_options.hasTimeRangeFilter()) {
+            && !m_options.hasSizeRangeFilter() && !m_options.hasTimeRangeFilter()
+            && !m_options.hiddenOnly()) {
             return SearchError(FileNameSearchErrorCode::KeywordIsEmpty);
         }
 

--- a/src/dfm-search/dfm-search-lib/filenamesearch/filenamestrategies/indexedstrategy.cpp
+++ b/src/dfm-search/dfm-search-lib/filenamesearch/filenamestrategies/indexedstrategy.cpp
@@ -669,6 +669,19 @@ Lucene::QueryPtr FileNameIndexedStrategy::buildLuceneQuery(const IndexQuery &que
         break;
     }
 
+    // hiddenOnly 本身就是有效主查询条件，不依赖其他 keyword/type/ext。
+    // 让 "下载的隐藏文件" 这类无关键字的语义搜索能直接走 kIsHidden 倒排索引，
+    // 同时让后续 pathPrefixQuery / excludedPaths / hidden filter 能正确叠加。
+    // 必须在 pathPrefixQuery 等依赖 hasValidQuery 的块之前注入。
+    if (m_options.hiddenOnly()) {
+        QueryPtr hiddenOnlyQuery = Lucene::newLucene<Lucene::TermQuery>(
+                Lucene::newLucene<Lucene::Term>(
+                        LuceneFieldNames::FileName::kIsHidden,
+                        L"Y"));
+        finalQuery->add(hiddenOnlyQuery, Lucene::BooleanClause::MUST);
+        hasValidQuery = true;
+    }
+
     // Add time range filter query
     if (m_options.hasTimeRangeFilter()) {
         TimeRangeFilter filter = m_options.timeRangeFilter();
@@ -730,15 +743,6 @@ Lucene::QueryPtr FileNameIndexedStrategy::buildLuceneQuery(const IndexQuery &que
                         LuceneFieldNames::FileName::kIsHidden,
                         L"Y"));
         finalQuery->add(hiddenQuery, Lucene::BooleanClause::MUST_NOT);
-    }
-
-    // When hiddenOnly is true, only return hidden files (MUST kIsHidden:Y)
-    if (hasValidQuery && m_options.hiddenOnly()) {
-        QueryPtr hiddenOnlyQuery = Lucene::newLucene<Lucene::TermQuery>(
-                Lucene::newLucene<Lucene::Term>(
-                        LuceneFieldNames::FileName::kIsHidden,
-                        L"Y"));
-        finalQuery->add(hiddenOnlyQuery, Lucene::BooleanClause::MUST);
     }
 
     return hasValidQuery ? finalQuery : nullptr;


### PR DESCRIPTION
1. Fixed validation to allow hidden-only searches without keywords (like
"downloads' hidden files" case)
2. Moved hidden-only query condition to be processed earlier in lucene
query building
3. Added test case for hidden-only searches with no keywords
4. Ensured proper path and hidden filters are applied for hidden-only
queries

Log: Fixed hidden files search when no keywords are provided

Influence:
1. Test searching hidden files without keywords (e.g. "downloads' hidden
files")
2. Verify hidden-only searches work with path restrictions
3. Check that hidden files search still works normally with keywords
4. Test combinations of hidden-only with other filters (size, type,
etc.)

fix: 处理无关键字时的隐藏文件搜索问题

1. 修改验证逻辑以允许无关键字的仅搜索隐藏文件（如"下载的隐藏文件"场景）
2. 将仅搜索隐藏条件的处理移至lucene查询构建的更早阶段
3. 添加无关键字时仅搜索隐藏文件的测试用例
4. 确保仅搜索隐藏查询正确应用路径和隐藏文件过滤器

Log: 修复无关键字时的隐藏文件搜索功能

Influence:
1. 测试无关键字时搜索隐藏文件（如"下载的隐藏文件"）
2. 验证带有路径限制的仅隐藏文件搜索是否正常工作
3. 检查带有关键字的隐藏文件搜索是否仍然正常
4. 测试仅隐藏文件搜索与其他筛选条件（大小、类型等）的组合情况

## Summary by Sourcery

Allow hidden-only file searches without keywords and ensure they are correctly handled in the filename search pipeline.

Bug Fixes:
- Allow hidden-only filename searches to run when no keyword is provided by treating the hidden-only flag as a valid query condition.
- Ensure Lucene queries for hidden-only searches always include the hidden file constraint so path and other filters apply correctly.

Tests:
- Add a semantic search test case covering hidden-only searches without keywords to validate planner behavior.