### PR TITLE
refactor: refine semantic search classification logic

### DIFF
--- a/autotests/dfm-search-tests/tst_semantic_search.cpp
+++ b/autotests/dfm-search-tests/tst_semantic_search.cpp
@@ -708,19 +708,24 @@ bool checkIsSemanticQuery(SemanticRuleEngine *engine, IntentParser *parser,
     ParsedIntent intent;
     parser->parse(input, intent);
 
+    // Replicate isSemanticIntent() — keep in sync with semanticsearcher.cpp.
+    // 维度计数法：任何单维度都不算语义查询，至少 2 个维度组合才算。
+
+    // keyword_* 规则 span 单独成立
     for (const MatchSpan &span : intent.consumedSpans()) {
         if (span.ruleId().startsWith("keyword_")) {
             return true;
         }
     }
 
-    if (intent.hiddenOnly() || !intent.searchDirectories().isEmpty()) {
-        return true;
-    }
-
-    const bool hasConstraint = intent.timeConstraint().isValid()
-            || intent.sizeConstraint().isValid()
-            || intent.recentOnly();
+    int dimensionCount = 0;
+    if (!intent.searchDirectories().isEmpty()) ++dimensionCount;
+    if (intent.hiddenOnly()) ++dimensionCount;
+    if (intent.recentOnly()) ++dimensionCount;
+    if (intent.timeConstraint().isValid()) ++dimensionCount;
+    if (intent.sizeConstraint().isValid()) ++dimensionCount;
+    if (!intent.fileExtensions().isEmpty()) ++dimensionCount;
+    if (!intent.keywords().isEmpty()) ++dimensionCount;
     bool hasTargetRule = false;
     for (const MatchSpan &span : intent.consumedSpans()) {
         if (span.ruleId().startsWith("target_")) {
@@ -728,18 +733,9 @@ bool checkIsSemanticQuery(SemanticRuleEngine *engine, IntentParser *parser,
             break;
         }
     }
-    const bool hasTarget = hasTargetRule || !intent.keywords().isEmpty()
-            || !intent.fileExtensions().isEmpty() || intent.searchTarget() != SearchTarget::All;
+    if (hasTargetRule) ++dimensionCount;
 
-    if (hasConstraint && hasTarget) {
-        return true;
-    }
-
-    if (hasTargetRule && !intent.fileExtensions().isEmpty()) {
-        return true;
-    }
-
-    return !intent.keywords().isEmpty() && !intent.fileExtensions().isEmpty();
+    return dimensionCount >= 2;
 }
 
 }   // namespace
@@ -782,6 +778,8 @@ private Q_SLOTS:
     void noiseWordsOnly();
     void hiddenFile();
     void structuredKeywordRule();
+    void locationOnlyRejected();
+    void locationPlusDimensionAccepted();
 
 private:
     SemanticRuleEngine *m_engine = nullptr;
@@ -1009,10 +1007,14 @@ void tst_IsSemanticQuery::noiseWordsOnly()
 
 void tst_IsSemanticQuery::hiddenFile()
 {
+    // hiddenOnly + target "文件" = 2 维度 → 通过
     QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "隐藏文件"));
     QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "隐藏的文件"));
-    QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "藏起来的"));
-    QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "看不到的"));
+    // 纯属性槽单维度 → 不通过（与"打开过的"、"隐藏的"一致）
+    QVERIFY(!checkIsSemanticQuery(m_engine, m_parser, "藏起来的"));
+    QVERIFY(!checkIsSemanticQuery(m_engine, m_parser, "看不到的"));
+    QVERIFY(!checkIsSemanticQuery(m_engine, m_parser, "隐藏的"));
+    // time + hiddenOnly = 2 维度 → 通过
     QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "今天的隐藏文件"));
 }
 
@@ -1021,6 +1023,25 @@ void tst_IsSemanticQuery::structuredKeywordRule()
     QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "包含测试的文件"));
     QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "文件名包含测试的文档"));
     QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "文件内容包含配置的文档"));
+}
+
+void tst_IsSemanticQuery::locationOnlyRejected()
+{
+    // 仅命中位置槽、无其他维度 —— 不应通过语义查询检查。
+    // 这类查询本质是"列出某目录所有文件"，indexedstrategy 没有列全部文件的能力，
+    // 由 guardNonSemantic 拦下报 InvalidQuery，避免进入 doSearch 后空关键字报错。
+    QVERIFY(!checkIsSemanticQuery(m_engine, m_parser, "下载"));
+    QVERIFY(!checkIsSemanticQuery(m_engine, m_parser, "微信"));
+    QVERIFY(!checkIsSemanticQuery(m_engine, m_parser, "桌面"));
+}
+
+void tst_IsSemanticQuery::locationPlusDimensionAccepted()
+{
+    // 位置槽 + 其他维度 —— 应通过语义查询检查。
+    QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "下载的隐藏文件"));   // location + hiddenOnly
+    QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "下载的文档"));         // location + fileExtensions
+    QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "下载的pdf"));          // location + fileExtensions
+    QVERIFY(checkIsSemanticQuery(m_engine, m_parser, "桌面的今天的文件"));   // location + time + target
 }
 
 // ===== tst_SearchTarget =====
@@ -1301,6 +1322,7 @@ private Q_SLOTS:
     void fileNameOnlyTarget();
     void contentOnlyTarget();
     void hiddenOnlyNoKeyword();
+    void noKeywordWithFileExtensions();
 
 private:
     ParsedIntent makeIntent(const QStringList &keywords, SearchTarget target) const;
@@ -1372,13 +1394,33 @@ void tst_SemanticQueryBuilderTarget::hiddenOnlyNoKeyword()
     QVERIFY(plan.includeHidden);
     QVERIFY(plan.searchDirectories == QStringList { QStringLiteral("/home/test/Downloads") });
 
-    // fileName 路径必须构建（即使关键字为空）—— 否则搜索根本不会执行
-    // indexedstrategy 依赖空关键字的 fileNameQuery 走 Simple 分支，由 hiddenOnlyQuery 兜底
-    QVERIFY(plan.fileNameQuery.keyword().isEmpty());
+    // 无关键字时改用 wildcard "*" 匹配所有文件名 ——
+    // indexedstrategy Wildcard 分支 buildWildcardQuery("*") 生成匹配所有文件名的 WildcardQuery，
+    // 让 pathPrefixQuery / hiddenOnlyQuery 作为真正的过滤器叠加。
+    QCOMPARE(plan.fileNameQuery.keyword(), QStringLiteral("*"));
+    QCOMPARE(plan.fileNameQuery.type(), SearchQuery::Type::Wildcard);
 
     // content/ocr 不应启用（hiddenOnly 强制 FileNameOnly，且无关键字）
     QVERIFY(!plan.contentQuery.has_value());
     QVERIFY(!plan.ocrQuery.has_value());
+}
+
+void tst_SemanticQueryBuilderTarget::noKeywordWithFileExtensions()
+{
+    // "今天的图片"、"下载的pdf" 这类有 fileExtensions 但无 keyword 的查询：
+    // fileNameQuery 必须保持空 Simple（不是 wildcard "*"），否则 determineSearchType
+    // 会把 wildcard "*" 误导进 Combined 分支用 buildSimpleQuery("*") 走 NGram —— 错误。
+    // 空 Simple 让 determineSearchType 走 Combined(ext only)，由 extQuery 作主查询条件。
+    SemanticQueryBuilder builder;
+    ParsedIntent intent;
+    intent.setKeywords({});
+    intent.setFileExtensions({ "png", "jpg" });
+    intent.setSearchTarget(SearchTarget::All);
+
+    SemanticSearchPlan plan = builder.build(intent);
+
+    QVERIFY(plan.fileNameQuery.keyword().isEmpty());
+    QCOMPARE(plan.fileNameQuery.type(), SearchQuery::Type::Simple);
 }
 
 // ===== Factory functions =====

--- a/src/dfm-search/dfm-search-lib/semantic/semanticquerybuilder.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/semanticquerybuilder.cpp
@@ -91,8 +91,18 @@ SemanticSearchPlan SemanticQueryBuilder::build(const ParsedIntent &intent)
         } else if (intent.keywords().size() > 1) {
             plan.fileNameQuery = SearchFactory::createQuery(intent.keywords(), SearchQuery::Type::Boolean);
         } else {
-            // No keywords: search all files (use wildcard to match everything)
-            plan.fileNameQuery = SearchFactory::createQuery("");
+            // 无关键字时的兜底 —— 必须区分是否有 fileExtensions，避免走错 indexedstrategy 分支：
+            // - 有 fileExtensions（"今天的图片"、"下载的pdf"）：保持空 Simple query，让
+            //   determineSearchType 走 Combined 分支，由 extQuery 作为主查询条件
+            // - 无 fileExtensions（"桌面的文件"、"下载的隐藏文件"、"下载的文件"）：用
+            //   wildcard "*" 匹配所有文件名，让 pathPrefixQuery / hiddenOnlyQuery 作为
+            //   真正的过滤器（Wildcard 分支不会被 Combined 误导走 NGram）
+            if (!intent.fileExtensions().isEmpty()) {
+                plan.fileNameQuery = SearchFactory::createQuery("");
+            } else {
+                plan.fileNameQuery = SearchFactory::createQuery(QStringLiteral("*"),
+                        SearchQuery::Type::Wildcard);
+            }
         }
 
         plan.fileNameOptions = opts;

--- a/src/dfm-search/dfm-search-lib/semantic/semanticsearcher.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/semanticsearcher.cpp
@@ -40,60 +40,35 @@ bool hasTargetRuleSpan(const ParsedIntent &intent)
     return false;
 }
 
-bool hasConstraintSignal(const ParsedIntent &intent)
+// 计算语义维度个数。任何单维度单独都不算语义查询（"下载"、"隐藏的"、"打开过的"、
+// "图片"、"去年"、"大于10M" 都只是单维度），必须至少 2 个维度组合才表达完整搜索意图。
+// 维度：location / hiddenOnly / recentOnly / time / size / fileType / keyword / target
+int countSemanticDimensions(const ParsedIntent &intent)
 {
-    return intent.timeConstraint().isValid() || intent.sizeConstraint().isValid()
-            || intent.recentOnly();
-}
-
-bool hasLocationSignal(const ParsedIntent &intent)
-{
-    return intent.hiddenOnly() || !intent.searchDirectories().isEmpty();
-}
-
-bool hasKeywordAndFileType(const ParsedIntent &intent)
-{
-    return !intent.keywords().isEmpty() && !intent.fileExtensions().isEmpty();
-}
-
-bool hasFileTypeAndTarget(const ParsedIntent &intent)
-{
-    return !intent.fileExtensions().isEmpty() && hasTargetRuleSpan(intent);
-}
-
-bool hasConstraintAndTarget(const ParsedIntent &intent)
-{
-    if (!hasConstraintSignal(intent)) {
-        return false;
-    }
-
-    return hasTargetRuleSpan(intent) || !intent.keywords().isEmpty()
-            || !intent.fileExtensions().isEmpty() || intent.searchTarget() != SearchTarget::All;
+    int count = 0;
+    if (!intent.searchDirectories().isEmpty()) ++count;   // location
+    if (intent.hiddenOnly()) ++count;                     // hiddenOnly 属性
+    if (intent.recentOnly()) ++count;                     // recentOnly 属性
+    if (intent.timeConstraint().isValid()) ++count;       // time 约束
+    if (intent.sizeConstraint().isValid()) ++count;       // size 约束
+    if (!intent.fileExtensions().isEmpty()) ++count;      // fileType
+    if (!intent.keywords().isEmpty()) ++count;            // keyword (unconsumed text)
+    if (hasTargetRuleSpan(intent)) ++count;               // target 名词 (文件/文件名/文件夹)
+    return count;
 }
 
 bool isSemanticIntent(const ParsedIntent &intent)
 {
-    if (hasLocationSignal(intent)) {
-        return true;
-    }
-
+    // 结构化关键字规则 (keyword_* span) 本身已表达明确搜索意图，单独成立
+    // (如 "包含测试的文件"、"文件名包含报告的文档")
     if (hasKeywordRuleSpan(intent)) {
         return true;
     }
 
-    if (hasConstraintAndTarget(intent)) {
-        return true;
-    }
-
-    if (hasFileTypeAndTarget(intent)) {
-        return true;
-    }
-
-    if (hasKeywordAndFileType(intent)) {
-        return true;
-    }
-
-    return false;
+    // 至少 2 个语义维度组合才算完整语义查询。
+    // 单维度（纯位置/纯属性/纯时间/纯大小/纯文件类型）不构成可执行的搜索意图，
+    // 由 guardNonSemantic 拦下报 InvalidQuery，避免进入 doSearch 后空关键字报错。
+    return countSemanticDimensions(intent) >= 2;
 }
 
 }   // namespace
@@ -199,10 +174,16 @@ void SemanticSearcherData::doSearch(const QString &naturalLanguage, const QStrin
         }
     };
 
-    auto onError = [](const SearchError &error) {
+    // 引擎错误也必须触发计数归零检查，否则上层会一直阻塞到 60s 超时。
+    // 校验失败（如 KeywordIsEmpty）会让 GenericSearchEngine::search 在
+    // emit errorOccurred 后直接 return，不会 emit searchFinished ——
+    // 此时必须由 onError 兜底减计数，把错误视为引擎完成。
+    auto onError = [this, onFinished](const SearchError &error) {
         qWarning() << "Search error:" << error.message();
         // Don't propagate individual engine errors to caller
         // The other engines may still produce valid results
+        // 但仍需减计数，否则 pendingFinishCount 永不到 0
+        onFinished({});
     };
 
     // Step 6: Clean up any previous search engines


### PR DESCRIPTION
1. Modified semantic query classification logic to use a dimension
counting approach
2. Now requires at least 2 dimensions to qualify as semantic query
(location/time/size etc.)
3. Single-dimension queries like "Downloads" or "hidden" are no longer
considered semantic
4. Changed empty keyword handling to use "*" wildcard instead of blank
query
5. Updated tests to verify new classification behavior

Log:
1. Location-only searches like "Downloads" now correctly rejected as
non-semantic
2. Wildcard "*" is now used when no keywords provided with other
dimensions

Influence:
1. Test single-dimension queries are rejected (e.g. "hidden")
2. Verify multi-dimension queries work (e.g. "hidden files in
Downloads")
3. Check wildcard handling for keyword-less searches
4. Validate error handling for invalid queries

refactor: 优化语义搜索分类逻辑

1. 修改语义查询分类逻辑，采用维度计数方法
2. 现在需要至少2个维度才能认定为语义查询（位置/时间/大小等）
3. 单一维度的查询如"下载"或"隐藏"不再视为语义查询
4. 将空关键字处理改为使用"*"通配符而非空白查询
5. 更新测试以验证新的分类行为

Log:
1. 单一位置查询如"下载"现在会正确判定为非语义查询
2. 没有关键字但有其他维度时现在会使用"*"通配符

Influence:
1. 测试单一维度查询会被拒绝（如"隐藏"）
2. 验证多维度查询正常工作（如"下载的隐藏文件"）
3. 检查无关键字搜索的通配符处理
4. 验证错误处理机制对无效查询的处理

## Summary by Sourcery

Refine semantic query classification to require multiple intent dimensions and ensure engine errors properly complete searches.

Bug Fixes:
- Treat engine error callbacks as completion events to avoid hanging pending search counters.

Enhancements:
- Replace rule-combination semantic detection with a dimension-counting approach requiring at least two semantic dimensions.
- Ensure location-only and single-attribute queries are rejected as non-semantic while multi-dimension queries are accepted.
- Use a wildcard filename query when no keywords are provided but other semantic dimensions exist.

Tests:
- Align semantic query test helper with the new dimension-counting logic and expand coverage for location-only, multi-dimension, and hidden-file scenarios.