### PR TITLE
feat: resolve location-filetype conflict in search

### DIFF
--- a/autotests/dfm-search-tests/tst_chinese_nlp.cpp
+++ b/autotests/dfm-search-tests/tst_chinese_nlp.cpp
@@ -235,6 +235,12 @@ private Q_SLOTS:
     void location_wechatConsumesTriggerWords();
     void location_imReceiveConsumesTriggerWords();
 
+    // Location vs filetype conflict resolution tests
+    void location_filetypeConflict_videosDirMusic();
+    void location_filetypeConflict_musicDirVideo();
+    void location_filetypeConflict_picturesDirDocument();
+    void location_filetypeConflict_documentsDirPicture();
+
     // End-to-end combined tests
     void combined_timeAndFiletype();
     void combined_timeAndFiletype_multi();
@@ -2231,6 +2237,83 @@ void tst_ChineseNLP::location_imReceiveConsumesTriggerWords()
     } else {
         QSKIP("Could not create fake WeChat dir for IM receive test");
     }
+}
+
+// ===== Location vs Filetype Conflict Resolution Tests =====
+//
+// When a word like "视频" appears in "视频目录", the location rule
+// "视频目录" and the filetype rule "视频" both match. The filetype
+// match span is fully contained within the location span, so it must
+// be suppressed — only a distinct filetype word elsewhere in the
+// query should survive.
+
+void tst_ChineseNLP::location_filetypeConflict_videosDirMusic()
+{
+    // "视频目录中的音乐" → location(Videos) + filetype(audio only)
+    // "视频" is contained in "视频目录" → filetype_video suppressed
+    // "音乐" is outside the location span → filetype_audio survives
+    const QString videosPath = QStandardPaths::writableLocation(QStandardPaths::MoviesLocation);
+    ParsedIntent intent;
+    m_parser->parse(QStringLiteral("视频目录中的音乐"), intent);
+    QCOMPARE(intent.searchDirectories().size(), 1);
+    QCOMPARE(intent.searchDirectories().first(), videosPath);
+    // Only audio extensions — video extensions must NOT be present
+    QVERIFY2(setEquals(intent.fileExtensions(), audioExpectedExts()),
+             qPrintable("Expected only audio extensions, got: "
+                        + intent.fileExtensions().join(", ")));
+    QVERIFY(intent.keywords().isEmpty());
+}
+
+void tst_ChineseNLP::location_filetypeConflict_musicDirVideo()
+{
+    // "音乐目录中的视频" → location(Music) + filetype(video only)
+    // "音乐" is contained in "音乐目录" → filetype_audio suppressed
+    // "视频" is outside the location span → filetype_video survives
+    const QString musicPath = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
+    ParsedIntent intent;
+    m_parser->parse(QStringLiteral("音乐目录中的视频"), intent);
+    QCOMPARE(intent.searchDirectories().size(), 1);
+    QCOMPARE(intent.searchDirectories().first(), musicPath);
+    QVERIFY2(setEquals(intent.fileExtensions(), videoExpectedExts()),
+             qPrintable("Expected only video extensions, got: "
+                        + intent.fileExtensions().join(", ")));
+    QVERIFY(intent.keywords().isEmpty());
+}
+
+void tst_ChineseNLP::location_filetypeConflict_picturesDirDocument()
+{
+    // "图片目录中的文档" → location(Pictures) + filetype(document_general only)
+    // "图片" is contained in "图片目录" → filetype_image suppressed
+    // "文档" is outside the location span → filetype_document_general survives
+    const QString picsPath = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+    ParsedIntent intent;
+    m_parser->parse(QStringLiteral("图片目录中的文档"), intent);
+    QCOMPARE(intent.searchDirectories().size(), 1);
+    QCOMPARE(intent.searchDirectories().first(), picsPath);
+    // Document extensions present, but NOT image extensions (e.g. "jpg")
+    QVERIFY(!intent.fileExtensions().isEmpty());
+    QVERIFY(!intent.fileExtensions().contains("jpg"));
+    QVERIFY(!intent.fileExtensions().contains("png"));
+    QVERIFY(intent.fileExtensions().contains("doc"));
+    QVERIFY(intent.fileExtensions().contains("pdf"));
+    QVERIFY(intent.keywords().isEmpty());
+}
+
+void tst_ChineseNLP::location_filetypeConflict_documentsDirPicture()
+{
+    // "文档目录中的图片" → location(Documents) + filetype(image only)
+    // "文档" is contained in "文档目录" → filetype_document_general suppressed
+    // "图片" is outside the location span → filetype_image survives
+    const QString docsPath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    ParsedIntent intent;
+    m_parser->parse(QStringLiteral("文档目录中的图片"), intent);
+    QCOMPARE(intent.searchDirectories().size(), 1);
+    QCOMPARE(intent.searchDirectories().first(), docsPath);
+    // Only image extensions — document extensions must NOT be present
+    QVERIFY2(setEquals(intent.fileExtensions(), imageExpectedExts()),
+             qPrintable("Expected only image extensions, got: "
+                        + intent.fileExtensions().join(", ")));
+    QVERIFY(intent.keywords().isEmpty());
 }
 
 QObject *create_tst_ChineseNLP()

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,41 @@
+util-dfm (1.3.60) unstable; urgency=medium
+
+  * fix(dfm-io): drain GLib deferred callbacks after g_file_enumerate_children
+  * fix(dfm-io): close FTS tree in destructor to prevent memory leak
+  * perf(dfm-io): cache statx results in DFileInfoPrivate::attributesBySelf
+  * fix: prevent BOM character loss in path concatenation
+  * Revert "fix(dfm-io): drain GLib deferred callbacks after g_file_enumerate_children"
+  * feat: add semantic query validation in search
+  * feat: expand supported file extensions for search
+  * refactor: update semantic search rules and tests
+  * fix: improve IM received files search accuracy
+  * feat: enhance Chinese NLP action recognition
+  * feat: add hidden file search support for semantic search
+  * feat: add hidden-only file search functionality
+  * feat: add file extension filter support for searches
+  * fix: update semantic search validation conditions
+  * feat: add file extension field to search index
+  * feat: implement semantic search routing
+  * refactor: optimize file extension filtering in search strategies
+  * refactor: convert HighlightOptions to Pimpl pattern
+  * fix: refactor ParsedIntent to use pimpl pattern
+  * refactor: refactor semantic types to use PIMPL pattern
+  * feat: implement recent files search via DBus RecentManager
+  * test: add recent search engine unit tests
+  * refactor: update recent search D-Bus integration
+  * fix: adjust search directory priority in semantic search
+  * feat: add parseIntent API for semantic search preview
+  * feat: expand supported document file extensions
+  * feat: enhance semantic search detection logic
+  * fix: handle hidden files search without keywords
+  * refactor: refine semantic search classification logic
+  * fix: enhance filetype matching rules and semantic detection
+  * feat: resolve location-filetype conflict in search
+  * feat: add version info to dfm-searcher client
+  * fix: correct loading of string list from DConfig
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Thu, 09 Jul 2026 18:54:26 +0800
+
 util-dfm (1.3.59) unstable; urgency=medium
 
   * fix: improve symlink handling in filename search

--- a/debian/rules
+++ b/debian/rules
@@ -43,4 +43,5 @@ $(shell sed -e 's/@QT_SUFFIX@/$(QT_SUFFIX)/g' \
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-	  -DHOST_MULTIARCH="$(DEB_HOST_MULTIARCH)"
+	  -DHOST_MULTIARCH="$(DEB_HOST_MULTIARCH)" \
+	  -DVERSION="$(DEB_VERSION_UPSTREAM)"

--- a/src/dfm-search/dfm-search-client/CMakeLists.txt
+++ b/src/dfm-search/dfm-search-client/CMakeLists.txt
@@ -21,6 +21,11 @@ find_package(Qt${QT_VERSION_MAJOR}Core REQUIRED)
 
 add_executable(${PROJECT_NAME} ${SRCS})
 
+if(NOT DEFINED VERSION)
+    set(VERSION "0.0.0")
+endif()
+target_compile_definitions(${PROJECT_NAME} PRIVATE VERSION="${VERSION}")
+
 include_directories(
     ${PROJECT_SOURCE_DIR}/../dfm-search-lib/include
 )

--- a/src/dfm-search/dfm-search-client/cli_options.cpp
+++ b/src/dfm-search/dfm-search-client/cli_options.cpp
@@ -9,6 +9,7 @@
 #include <QCoreApplication>
 #include <QFileInfo>
 #include <iostream>
+#include <cstdlib>
 
 using namespace dfmsearch;
 using namespace std;
@@ -49,7 +50,8 @@ CliOptions::CliOptions()
       m_timeLastYearOption(QStringList() << "time-last-year", "Filter files from last year"),
       m_timeRangeOption(QStringList() << "time-range", "Custom time range (start,end)", "range"),
       m_sizeMinOption(QStringList() << "size-min", "Minimum file size (e.g., 1K, 10M, 1G, 512)", "size"),
-      m_sizeMaxOption(QStringList() << "size-max", "Maximum file size (e.g., 1K, 10M, 1G, 512)", "size")
+      m_sizeMaxOption(QStringList() << "size-max", "Maximum file size (e.g., 1K, 10M, 1G, 512)", "size"),
+      m_versionOption(QStringList() << "version", "Show version information and exit")
 {
     setupOptions();
 }
@@ -58,6 +60,7 @@ void CliOptions::setupOptions()
 {
     m_parser.setApplicationDescription("DFM Search Client");
     m_parser.addHelpOption();
+    m_parser.addOption(m_versionOption);
 
     // Basic options
     m_parser.addOption(m_typeOption);
@@ -154,6 +157,7 @@ void CliOptions::printHelp() const
     std::cout << "  --json, -j                     Output results in JSON format" << std::endl;
     std::cout << "  --verbose, -v                  Enable verbose output with detailed result information" << std::endl;
     std::cout << "  --help                         Display this help" << std::endl;
+    std::cout << "  --version                      Show version information and exit" << std::endl;
     std::cout << std::endl;
     std::cout << "Examples:" << std::endl;
     std::cout << "  # Basic filename search" << std::endl;
@@ -197,6 +201,15 @@ bool CliOptions::parse(QCoreApplication &app, SearchCliConfig &config)
     }
 
     m_parser.process(app);
+
+    if (m_parser.isSet(m_versionOption)) {
+        QString name = QCoreApplication::applicationName().isEmpty()
+            ? QStringLiteral("dfm-searcher")
+            : QCoreApplication::applicationName();
+        std::cout << name.toStdString() << " "
+                  << QCoreApplication::applicationVersion().toStdString() << std::endl;
+        std::exit(0);
+    }
 
     QStringList positionalArgs = m_parser.positionalArguments();
 

--- a/src/dfm-search/dfm-search-client/cli_options.h
+++ b/src/dfm-search/dfm-search-client/cli_options.h
@@ -129,6 +129,7 @@ private:
     // File size range filtering options
     QCommandLineOption m_sizeMinOption;
     QCommandLineOption m_sizeMaxOption;
+    QCommandLineOption m_versionOption;
 };
 
 }   // namespace dfmsearch

--- a/src/dfm-search/dfm-search-client/main.cpp
+++ b/src/dfm-search/dfm-search-client/main.cpp
@@ -25,6 +25,10 @@
 
 #include <iostream>
 
+#ifndef VERSION
+#define VERSION "unknown"
+#endif
+
 using namespace dfmsearch;
 
 /**
@@ -161,6 +165,7 @@ static SearchQuery createSearchQuery(const SearchCliConfig &config)
 int main(int argc, char *argv[])
 {
     QCoreApplication app(argc, argv);
+    app.setApplicationVersion(QString::fromLatin1(VERSION));
 
     // Parse CLI arguments
     CliOptions cliOptions;

--- a/src/dfm-search/dfm-search-lib/semantic/extractors/filetypeextractor.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/extractors/filetypeextractor.cpp
@@ -30,6 +30,24 @@ void FileTypeExtractor::extract(const QString &input, ParsedIntent &intent)
         const QRegularExpressionMatch &m = matches[i];
         const QVariantMap metadata = m_engine->ruleMetadata("filetype", ruleIds[i]);
 
+        // Skip a filetype match whose span is fully contained within an
+        // already-consumed span (e.g. "视频" consumed by the location rule
+        // "视频目录"). This resolves the location-vs-filetype ambiguity where
+        // the same word ("视频", "音乐", "文档", "图片") triggers both a
+        // location directory and a file type: the location interpretation wins,
+        // and a distinct filetype word elsewhere in the query survives.
+        bool contained = false;
+        for (const MatchSpan &existing : intent.consumedSpans()) {
+            if (m.capturedStart() >= existing.start()
+                    && m.capturedEnd() <= existing.end()) {
+                contained = true;
+                break;
+            }
+        }
+        if (contained) {
+            continue;
+        }
+
         // Always consume the matched span so the matched text doesn't leak into keywords
         MatchSpan span;
         span.setStart(m.capturedStart());

--- a/src/dfm-search/dfm-search-lib/semantic/intentparser.cpp
+++ b/src/dfm-search/dfm-search-lib/semantic/intentparser.cpp
@@ -47,12 +47,15 @@ QStringList IntentParser::extractorNames() const
 
 void IntentParser::initDefaultExtractors()
 {
-    // Order matters: keyword MUST be last (depends on consumedSpans)
+    // Order matters: Location must run before FileType so that span-based
+    // overlap suppression in FileTypeExtractor can drop a filetype match that
+    // is fully contained within a location span (e.g. "视频" inside "视频目录").
+    // Keyword MUST be last (depends on consumedSpans).
+    addExtractor(std::make_unique<LocationExtractor>(m_engine));
     addExtractor(std::make_unique<TimeExtractor>(m_engine));
     addExtractor(std::make_unique<FileTypeExtractor>(m_engine));
     addExtractor(std::make_unique<SizeExtractor>(m_engine));
     addExtractor(std::make_unique<ActionExtractor>(m_engine));
-    addExtractor(std::make_unique<LocationExtractor>(m_engine));
     addExtractor(std::make_unique<TargetExtractor>(m_engine));
     addExtractor(std::make_unique<KeywordExtractor>(m_engine));
 }

--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/location_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/location_rules.json
@@ -8,7 +8,7 @@
             "rules": [
                 {
                     "id": "loc_desktop",
-                    "pattern": "桌面",
+                    "pattern": "桌面|屏幕上|电脑桌面",
                     "description": "Desktop directory",
                     "enabled": true,
                     "priority": 200,
@@ -19,7 +19,7 @@
                 },
                 {
                     "id": "loc_download",
-                    "pattern": "下载",
+                    "pattern": "下载|下载目录|下下来的|浏览器下载",
                     "description": "Downloads directory",
                     "enabled": true,
                     "priority": 200,
@@ -30,7 +30,7 @@
                 },
                 {
                     "id": "loc_documents_dir",
-                    "pattern": "文档目录|文档文件夹",
+                    "pattern": "文档里|文档下|文档中|我的文档|文档目录|文档文件夹",
                     "description": "Documents directory (must contain directory/folder word)",
                     "enabled": true,
                     "priority": 200,
@@ -41,7 +41,7 @@
                 },
                 {
                     "id": "loc_pictures_dir",
-                    "pattern": "图片目录|图片文件夹|照片目录|照片文件夹",
+                    "pattern": "图片里|图片下|图片中|图片目录|图片文件夹|照片目录|照片文件夹",
                     "description": "Pictures directory (must contain directory/folder word)",
                     "enabled": true,
                     "priority": 200,
@@ -52,7 +52,7 @@
                 },
                 {
                     "id": "loc_music_dir",
-                    "pattern": "音乐目录|音乐文件夹",
+                    "pattern": "音乐里|音乐下|音乐中|音乐目录|音乐文件夹",
                     "description": "Music directory (must contain directory/folder word)",
                     "enabled": true,
                     "priority": 200,
@@ -63,7 +63,7 @@
                 },
                 {
                     "id": "loc_videos_dir",
-                    "pattern": "视频目录|视频文件夹|电影目录|电影文件夹",
+                    "pattern": "视频里|视频下|视频中|视频目录|视频文件夹|电影目录|电影文件夹",
                     "description": "Videos directory (must contain directory/folder word)",
                     "enabled": true,
                     "priority": 200,

--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/noise_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/noise_rules.json
@@ -48,7 +48,7 @@
                 },
                 {
                     "id": "noise_location_connector",
-                    "pattern": "上的|里的|下的",
+                    "pattern": "上的|里的|下的|中的",
                     "description": "Location connector words to consume",
                     "enabled": true,
                     "priority": 190,


### PR DESCRIPTION
Implemented handling for cases where filetype and location keywords
overlap (e.g. "视频" in "视频目录"). The filetype match is now
suppressed when fully contained within a location span.

Key changes:
1. Added span containment check in FileTypeExtractor to skip matches
within consumed location spans
2. Reordered extractor execution to prioritize Location before FileType
to support span analysis
3. Enhanced Chinese location rules with more variants (e.g. "视频下",
"文档中")
4. Added test cases verifying conflict resolution in various scenarios
(videos+music, music+videos, etc.)

Log: Improved handling of search queries with overlapping location and
filetype terms

Influence:
1. Test with queries like "视频目录中的音乐" - should only match audio
files in Videos dir
2. Test "音乐目录中的视频" - should only match video files in Music dir
3. Verify combinations with pictures/documents work correctly
4. Test with newly added location variants like "视频下" or "图片中"
5. Ensure regular filetype matching still works when not in conflict

feat: 解决搜索中位置与文件类型冲突问题

实现了对文件类型和位置关键词重叠情况（如"视频目录"中的"视频"）的处理。当
文件类型匹配完全包含在位置范围内时，现在会跳过该文件类型匹配。

主要变更:
1. 在FileTypeExtractor中添加了范围包含检查，跳过已消费位置范围内的匹配
2. 重新排序提取器执行顺序，优先处理位置信息以支持范围分析
3. 增强中文位置规则，增加更多变体（如"视频下"、"文档中"）
4. 添加测试用例验证各种场景下的冲突解决（视频+音乐，音乐+视频等）

Log: 改进了对包含位置和文件类型重叠术语的搜索查询的处理

Influence:
1. 测试查询如"视频目录中的音乐" - 应只匹配视频目录中的音频文件
2. 测试"音乐目录中的视频" - 应只匹配音乐目录中的视频文件
3. 验证图片/文档组合是否能正常工作
4. 测试新增的位置变体如"视频下"或"图片中"
5. 确保无冲突时的常规文件类型匹配仍能正常工作
