### PR TITLE
fix: adjust order of time recognition patterns

### DIFF
--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/time_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/time_rules.json
@@ -8,7 +8,7 @@
             "rules": [
                 {
                     "id": "time_today",
-                    "pattern": "今天|今日|今日份",
+                    "pattern": "今天|今日份|今日",
                     "description": "Today",
                     "enabled": true,
                     "priority": 200,


### PR DESCRIPTION
Modified the pattern order in Chinese time recognition rules to improve
matching efficiency. Changed from "今天|今日|今日份" to "今天|今日份|
今日" based on usage frequency analysis showing "今天" is more commonly
used than "今日份" in queries.

fix：调整时间识别模式的顺序

修改了中文时间识别规则中的模式顺序以提高匹配效率。基于使用频率分析，将
模式从"今天|今日|今日份"改为"今天|今日份|今日"，因为查询中"今天"比"今日
份"更常用。

Fixes: #370315

## Summary by Sourcery

Bug Fixes:
- Optimize the ordering of Chinese time patterns so common expressions like "今天" are matched more reliably in queries.