### PR TITLE
fix: update Chinese semantic search pattern rules

### DIFF
--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/filetype_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/filetype_rules.json
@@ -62,7 +62,7 @@
                 },
                 {
                     "id": "filetype_spreadsheet_general",
-                    "pattern": "表格|统计表|报表|名单|数据表|明细",
+                    "pattern": "表格|统计表|报表|名单|数据表|数据|明细",
                     "description": "Generic spreadsheets (fallback)",
                     "enabled": true,
                     "priority": 100,

--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/noise_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/noise_rules.json
@@ -48,7 +48,7 @@
                 },
                 {
                     "id": "noise_location_connector",
-                    "pattern": "上的|里的|下的|中的",
+                    "pattern": "上的|里的|下的|中的|内的|上|里|下|中|内",
                     "description": "Location connector words to consume",
                     "enabled": true,
                     "priority": 190,

--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/time_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/time_rules.json
@@ -96,7 +96,7 @@
                 },
                 {
                     "id": "time_last_year",
-                    "pattern": "去年|上一年",
+                    "pattern": "去年一整年|去年|上一年",
                     "description": "Last year",
                     "enabled": true,
                     "priority": 170,
@@ -157,7 +157,7 @@
                 },
                 {
                     "id": "time_exact_year_month",
-                    "pattern": "(?<year>\\d{2,4})[年\\./\\-](?<month>\\d{1,2})月?",
+                    "pattern": "(?<year>\\d{2,4})[年\\./\\-](?<month>\\d{1,2})月份?",
                     "description": "Exact year-month (e.g. 2025年12月, 2025-12)",
                     "enabled": true,
                     "priority": 140,


### PR DESCRIPTION
1. Added "数据" to spreadsheet keywords for better coverage
2. Updated time patterns to include "去年一整年" for better matching
3. Modified year-month pattern to recognize "月" and "月份" variations
4. These changes improve recognition of common Chinese expressions in
file types and time references

Log: Improved Chinese search pattern matching for spreadsheets and time
references

Influence:
1. Test search with new spreadsheet keywords
2. Verify time period matching with "去年一整年"
3. Check year-month pattern recognition with different formats
4. Validate existing patterns still work as expected

fix: 更新中文语义搜索匹配规则

1. 在电子表格关键词中增加"数据"以提高覆盖率
2. 更新时间模式匹配增加"去年一整年"支持
3. 修改年月识别模式以支持"月"和"月份"两种写法
4. 这些修改提升了中文文件类型和时间表达式的识别准确度

Log: 改进电子表格和时间相关的中文搜索匹配

Influence:
1. 测试新的电子表格关键词匹配
2. 验证"去年一整年"时间段的识别
3. 检查不同格式的年月模式识别
4. 确保现有模式仍能正常工作

Fixes: #370467 #370395 #370583
