### PR TITLE
feat: update file type matching patterns

### DIFF
--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/filetype_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/filetype_rules.json
@@ -118,7 +118,7 @@
                 },
                 {
                     "id": "filetype_archive",
-                    "pattern": "压缩包|归档|源码包|打包文件|zip|rar",
+                    "pattern": "压缩包|归档|源码包|打包文件",
                     "description": "Archive files",
                     "enabled": true,
                     "priority": 150,
@@ -140,7 +140,7 @@
                 },
                 {
                     "id": "filetype_design_source",
-                    "pattern": "源文件|设计稿|矢量图|工程文件|psd|fig|sketch",
+                    "pattern": "源文件|设计稿|矢量图|工程文件",
                     "description": "Design source files",
                     "enabled": true,
                     "priority": 160,


### PR DESCRIPTION
1. Removed specific file extensions (zip/rar/psd/fig/sketch) from
Chinese file type matching rules
2. Kept only the generic Chinese descriptions for archive and design
source files
3. This makes the matching more language consistent and prevents
potential overlap with extension-based matching systems

Influence:
1. Test Chinese file search functionality to ensure it still matches the
intended file types
2. Verify that generic Chinese terms still properly identify archive and
design source files
3. Check for any regression in file type classification accuracy

feat: 更新文件类型匹配模式

1. 从中文文件类型匹配规则中移除了特定文件扩展名(zip/rar/psd/fig/sketch)
2. 只保留了归档文件和设计源文件的通用中文描述
3. 这使得匹配更加语言一致，并防止与基于扩展名的匹配系统潜在冲突

Influence:
1. 测试中文文件搜索功能，确保仍能匹配目标文件类型
2. 验证通用的中文术语仍能正确识别归档文件和设计源文件
3. 检查文件类型分类准确性是否出现回归

Fixes: #370661

## Summary by Sourcery

Enhancements:
- Relax file type patterns in zh_CN rules by removing explicit extensions such as zip/rar/psd/fig/sketch and keeping generic Chinese descriptions for archives and design sources.