### PR TITLE
fix: update Chinese location rule patterns

### DIFF
--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/location_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/location_rules.json
@@ -30,7 +30,7 @@
                 },
                 {
                     "id": "loc_documents_dir",
-                    "pattern": "文档里|文档下|文档中|我的文档|文档目录|文档文件夹",
+                    "pattern": "文档里|文档下|文档中|我的文档|文档目录|文档文件夹|文档库",
                     "description": "Documents directory (must contain directory/folder word)",
                     "enabled": true,
                     "priority": 200,
@@ -41,7 +41,7 @@
                 },
                 {
                     "id": "loc_pictures_dir",
-                    "pattern": "图片里|图片下|图片中|图片目录|图片文件夹|照片目录|照片文件夹",
+                    "pattern": "图片里|图片下|图片中|图片目录|图片文件夹|照片目录|照片文件夹|相册里|图片库",
                     "description": "Pictures directory (must contain directory/folder word)",
                     "enabled": true,
                     "priority": 200,


### PR DESCRIPTION
1. Added "文档库" (document library) to documents directory patterns
2. Added "相册里" (in the album) and "图片库" (picture library) to
pictures directory patterns
3. These changes expand the search matching for common Chinese user
expressions regarding document and picture locations

Influence:
1. Test Chinese language searches containing new pattern terms
2. Verify search results for document and picture locations match
expectations
3. Check behavior with mixed old and new pattern terms

fix: 更新中文位置规则匹配模式

1. 在文档目录模式中增加了"文档库"
2. 在图片目录模式中增加了"相册里"和"图片库"
3. 这些变更扩展了对中文用户常见文档和图片位置表达式的搜索匹配

Influence:
1. 测试包含新模式术语的中文搜索
2. 验证文档和图片位置的搜索结果是否符合预期
3. 检查新旧模式术语混合使用时的行为

Fixes: #370933 #370937

## Summary by Sourcery

Expand Chinese location rule patterns for document and picture directories to cover more common user expressions.

New Features:
- Broaden semantic matching for Chinese document locations by including additional directory terms.
- Broaden semantic matching for Chinese picture locations by including additional directory terms.

Tests:
- Ensure Chinese search queries using new and existing location phrases for documents and pictures return correct results.