### PR TITLE
chore: bump version to 1.3.70

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+util-dfm (1.3.70) unstable; urgency=medium
+
+  * perf(dfm-io): cache statx results in DFileInfoPrivate::attributesBySelf
+  * fix: prevent BOM character loss in path concatenation
+  * feat: add dvd+rw-format support for DVD RW erase
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 24 Jul 2026 09:51:44 +0800
+
 util-dfm (1.3.59) unstable; urgency=medium
 
   * fix: improve symlink handling in filename search


### PR DESCRIPTION
1.3.70

Log:

## Summary by Sourcery

Chores:
- Update release version entry in debian/changelog to 1.3.70.