### PR TITLE
fix: add missing WeChat group term in Chinese rules

### DIFF
--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/location_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/location_rules.json
@@ -74,7 +74,7 @@
                 },
                 {
                     "id": "loc_wechat_data",
-                    "pattern": "微信发给我的|微信发我的|微信接收的|微信群里的|微信群里|微信里|微信|vx|wechat",
+                    "pattern": "微信发给我的|微信发我的|微信接收的|微信群里的|微信群里|微信群|微信里|微信|vx|wechat",
                     "description": "WeChat received files directory — longer patterns first for maximal span consumption",
                     "enabled": true,
                     "priority": 180,


### PR DESCRIPTION
1. Added "微信群" to the pattern list for WeChat-related file locations
in Chinese localization rules
2. This term was missing from the previous pattern while other similar
terms were already included
3. Ensures more comprehensive matching of WeChat source references in
Chinese queries

Log: Improved WeChat file location detection by adding missing group
term

Influence:
1. Test Chinese file searches containing "微信群" term
2. Verify all other existing WeChat terms still work as expected
3. Check for any overlaps or conflicts with other location patterns
4. Validate search results for files from WeChat groups

fix: 在中文规则中添加缺失的微信群术语

1. 在微信相关文件位置的中文本地化规则模式中添加了"微信群"
2. 这个术语之前遗漏了，而其他相似术语已包含在列表中
3. 确保了中文查询中对微信来源引用的更全面匹配

Log: 通过添加缺失的群组术语改进了微信文件位置检测

Influence:
1. 测试包含"微信群"术语的中文文件搜索
2. 验证所有其他现有的微信术语仍正常工作
3. 检查与其他位置模式是否有重叠或冲突
4. 验证来自微信群组的文件搜索结果

Fixes: #371521
