### PR TITLE
fix(dfm-search): exclude WeChat monthly archive dirs from search results

### DIFF
--- a/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/location_rules.json
+++ b/src/dfm-search/dfm-search-lib/semantic/rules/zh_CN/location_rules.json
@@ -83,7 +83,7 @@
                             "Documents/xwechat_files/*/msg/file",
                             "Documents/xwechat_files/*/msg/video"
                         ],
-                        "exclude_patterns": ["*_thumb.jpg"],
+                        "exclude_patterns": ["*_thumb.jpg", "[0-9][0-9][0-9][0-9]-[0-9][0-9]"],
                         "include_hidden": false,
                         "im_received": true
                     }


### PR DESCRIPTION
## 根因分析

搜索"今天微信接受的文件"时，dfm-search 将范围收敛到微信接收目录 `~/Documents/xwechat_files/<用户>/msg/{file,video}`，并叠加"今天"时间过滤。微信在这些目录下按月创建归档目录 `YYYY-MM`（如 `2026-07`），真实接收的文件存放在月份目录内部。

**根因**：`loc_wechat_data` 规则的 `exclude_patterns` 仅含 `["*_thumb.jpg"]`，未覆盖月份目录名。这些月份目录被文件名索引以 `type=="dir"` 收录，被路径前缀查询（`kAncestorPaths`）+ "今天"时间过滤命中后，混入搜索结果。

**关键证据**：
- `location_rules.json:86` — `exclude_patterns` 遗漏月份目录模式
- `indexedstrategy.cpp:508-510` — 目录以 `type=="dir"` 被索引并随结果返回
- `semanticsearcher.cpp:291-296` — `onEngineFinished` 仅按 `*_thumb.jpg` 过滤，`2026-07` 不匹配从而通过

## 修复方案

在 `loc_wechat_data` 的 `exclude_patterns` 追加 `[0-9][0-9][0-9][0-9]-[0-9][0-9]`，复用既有 `QDir::match` 过滤通道，无需改 C++ 代码。

已在 Qt 6.8 验证 `QDir::match`：`2026-07`/`2026-12` 命中，`abcd-ef`、`2026-07.txt`、`202607` 均不命中，只精确排除月份目录、不误伤真实文件，且仅在微信搜索时生效。

## 改动安全评估

低风险：纯 JSON 配置追加，0 个代码调用者，复用已验证的 `exclude_patterns` → `QDir::match` 过滤机制，作用域仅限 `loc_wechat_data` 规则命中场景。
