### PR TITLE
fix: restrict path traversal check to file scheme in DEnumerator buildUrl

### DIFF
--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -455,10 +455,17 @@ QUrl DEnumeratorPrivate::buildUrl(const QUrl &url, const char *fileName)
         return QUrl();
     }
 
-    // 拦截路径遍历攻击，防止恶意文件名越权
     QByteArray fileNameBa(fileName);
-    if (fileNameBa.contains('/') || fileNameBa.contains('\\') || fileNameBa == "." || fileNameBa == "..") {
-        return QUrl();
+
+    // 路径遍历检查仅对本地文件系统 (file:/// 或无 scheme) 生效
+    // gio 的 trash:/// 后端对非用户主目录挂载点的回收站文件，使用反斜杠分隔的扁平路径
+    // 作为 GFileInfo 的 standard::name（例如 "\media\user\dev\.Trash-1000\files\x"），
+    // 这是合法的 trash 文件名而非恶意路径，故不应对其做路径遍历拦截。
+    const QString scheme = url.scheme();
+    if (scheme.isEmpty() || scheme == QLatin1String("file")) {
+        if (fileNameBa.contains('/') || fileNameBa.contains('\\') || fileNameBa == "." || fileNameBa == "..") {
+            return QUrl();
+        }
     }
 
     QByteArray path;


### PR DESCRIPTION
## 根因分析

`DEnumeratorPrivate::buildUrl()` 中的路径遍历安全检查 `fileNameBa.contains('\\')` 对 gio `trash:///` 后端使用反斜杠分隔的扁平文件名（如 `\media\user\dev\.Trash-1000\files\x`）返回空 `QUrl("")`，导致 `/media` 挂载点的回收站文件无法显示和清空。

- **回归来源**: commit `fd494fb`（PMS #367075, 2026-07-16）引入了该检查
- **证据**: 运行时日志显示第 2 个回收站文件 URL 为 `QUrl("")`，触发 `kIsNotTrashFileError`

## 修复方案

将路径遍历检查限制为仅对 `file:///` 或无 scheme 的本地文件系统生效，`trash:///` 等 gio 虚拟文件系统跳过该检查。

## 改动安全评估

低风险。修改仅限制检查的适用 scheme 范围，不改变 `buildUrl()` 签名或返回值语义。对 `file:///` scheme 行为完全不变。

## Summary by Sourcery

Bug Fixes:
- Allow gio trash:/// backend entries with backslash-separated flat filenames to be built into valid URLs instead of being dropped by the path traversal check.