### PR TITLE
fix: narrow path traversal check pattern in DEnumerator buildUrl

### DIFF
--- a/src/dfm-io/dfm-io/denumerator.cpp
+++ b/src/dfm-io/dfm-io/denumerator.cpp
@@ -463,7 +463,7 @@ QUrl DEnumeratorPrivate::buildUrl(const QUrl &url, const char *fileName)
     // 这是合法的 trash 文件名而非恶意路径，故不应对其做路径遍历拦截。
     const QString scheme = url.scheme();
     if (scheme.isEmpty() || scheme == QLatin1String("file")) {
-        if (fileNameBa.contains('/') || fileNameBa.contains('\\') || fileNameBa == "." || fileNameBa == "..") {
+        if (fileNameBa.contains("../") || fileNameBa.contains("..\\") || fileNameBa.startsWith("..")) {
             return QUrl();
         }
     }


### PR DESCRIPTION
## 补充修复

PR #377 已合入 master，将路径遍历检查限制为仅对 `file:///` scheme 生效（修复了 gio trash 回收站问题）。

本 PR 将路径遍历检查模式从 `contains('/') || contains('\\') || == "." || == ".."` 收窄为 `contains("../") || contains("..\\") || startsWith("..")`，与 release/eagle、release/snipe 分支保持一致，只拦截实际的路径遍历尝试。

PMS: BUG-372733

## Summary by Sourcery

Bug Fixes:
- Prevent valid filenames from being incorrectly blocked by over-broad path traversal checks when building file URLs.