### PR TITLE
chore: bump version to 1.3.71

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+util-dfm (1.3.71) unstable; urgency=medium
+
+  * fix: restrict path traversal check to file scheme in DEnumerator buildUrl
+
+ -- zhangsheng <zhangsheng@uniontech.com>  Thu, 06 Aug 2026 10:24:21 +0800
+
 util-dfm (1.3.70) unstable; urgency=medium
 
   * perf(dfm-io): cache statx results in DFileInfoPrivate::attributesBySelf


### PR DESCRIPTION
1.3.71

Log:

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 1.3.71 for a new release build.